### PR TITLE
[DK-256] Input 컴포넌트 구현

### DIFF
--- a/src/components/Input/Input.style.tsx
+++ b/src/components/Input/Input.style.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const InputWrapper = styled.div`
+  display: block;
+`;
+
+export const StyledInput = styled.input`
+  width: 100%;
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
+  padding: 8px;
+  box-sizing: border-box;
+  ::placeholder {
+    color: #cdcdcd;
+  }
+`;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,40 @@
+import * as S from './Input.style';
+
+interface Props {
+  type?: string;
+  name?: string;
+  placeholder?: string;
+  value?: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  readOnly?: boolean;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+const Input = ({
+  type = 'text',
+  name = '',
+  placeholder = '',
+  value,
+  onChange,
+  readOnly = false,
+  required = false,
+  disabled = false,
+  ...props
+}: Props) => (
+  <S.InputWrapper>
+    <S.StyledInput
+      type={type}
+      name={name}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      readOnly={readOnly}
+      required={required}
+      disabled={disabled}
+      {...props}
+    />
+  </S.InputWrapper>
+);
+
+export default Input;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { ComponentProps } from 'react';
 import * as S from './Input.style';
 
 interface Props {
@@ -5,7 +6,7 @@ interface Props {
   name?: string;
   placeholder?: string;
   value?: string;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  onChange: ComponentProps<'input'>['onChange'];
   readOnly?: boolean;
   required?: boolean;
   disabled?: boolean;

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Button } from './Button';
 export { Divider } from './Divider';
 export { Badge } from './Badge';
+export { Input } from './Input';


### PR DESCRIPTION
## 📌 과제 설명
Input 컴포넌트 개발했습니다.

## 👩‍💻 요구 사항과 구현 내용

### 캡처본
<img width="417" alt="Input 컴포넌트" src="https://user-images.githubusercontent.com/33307948/181456632-5b5ae1cf-b6d0-408f-89e7-c9bfcdbeef7c.png">

- 상속받아서 Input 컴포넌트에 props 넘기면 작동하고 스타일만 입혀놨다고 보시면 됩니다.


## ✅ 피드백 반영사항
- Styled import 방식
- Props 추가(type, name, placeholder, readOnly, required, disabled)