### PR TITLE
[DK-255] TeamBadge 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "^12.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.4.0",
     "recoil": "^0.7.4"
   },
   "devDependencies": {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,7 +7,7 @@ interface Props {
   fontSize?: string;
   fontColor?: string;
   borderRadius?: string;
-  children?: string;
+  children?: string | JSX.Element;
 }
 
 const Badge = ({

--- a/src/components/TeamBadge/TeamBadge.style.ts
+++ b/src/components/TeamBadge/TeamBadge.style.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const TeamBadgeWrapper = styled.div`
+  display: inline-block;
+  padding: 4px;
+`;
+export const BadgeInner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+`;
+export const IconWrapper = styled.div`
+  padding-right: 4px;
+`;

--- a/src/components/TeamBadge/TeamBadge.style.ts
+++ b/src/components/TeamBadge/TeamBadge.style.ts
@@ -4,12 +4,18 @@ export const TeamBadgeWrapper = styled.div`
   display: inline-block;
   padding: 4px;
 `;
+
 export const BadgeInner = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 8px;
 `;
+
 export const IconWrapper = styled.div`
   padding-right: 4px;
+`;
+
+export const BadgeText = styled.span`
+  font-size: ${(props) => props.theme.fontSize.b3};
 `;

--- a/src/components/TeamBadge/TeamBadge.tsx
+++ b/src/components/TeamBadge/TeamBadge.tsx
@@ -1,0 +1,56 @@
+import { Badge } from '@components/Badge';
+import {
+  MdSportsSoccer,
+  MdSportsBaseball,
+  MdSportsBasketball,
+  FaTableTennis,
+  FaBowlingBall,
+  GiShuttlecock,
+  MdSportsTennis,
+} from 'react-icons/all';
+
+import * as S from './TeamBadge.style';
+import { ColorProps, IconsProps } from './types';
+
+interface Props {
+  teamId: number;
+  sportsCategory: string;
+  name: string;
+}
+
+const Color: ColorProps = {
+  1: '#14A452',
+  2: '#62D2A2',
+  3: '#1FAB89',
+  4: '#14A452',
+  5: '#59B9A1',
+  6: '#16785F',
+};
+
+const Icons: IconsProps = {
+  soccer: <MdSportsSoccer size='21px' />,
+  baseball: <MdSportsBaseball size='21px' />,
+  basketball: <MdSportsBasketball size='21px' />,
+  tableTennis: <FaTableTennis size='21px' />,
+  bowling: <FaBowlingBall size='21px' />,
+  badminton: <GiShuttlecock size='21px' />,
+  tennis: <MdSportsTennis size='21px' />,
+};
+
+const TeamBadge = ({ teamId, sportsCategory, name }: Props) => (
+  <S.TeamBadgeWrapper>
+    <Badge
+      color={Color[teamId]}
+      width='100%'
+      height='38px'
+      borderRadius='5px'
+    >
+      <S.BadgeInner>
+        <S.IconWrapper>{Icons[sportsCategory]}</S.IconWrapper>
+        <span>{name}</span>
+      </S.BadgeInner>
+    </Badge>
+  </S.TeamBadgeWrapper>
+);
+
+export default TeamBadge;

--- a/src/components/TeamBadge/TeamBadge.tsx
+++ b/src/components/TeamBadge/TeamBadge.tsx
@@ -1,14 +1,7 @@
 import { Badge } from '@components/Badge';
-import {
-  MdSportsSoccer,
-  MdSportsBaseball,
-  MdSportsBasketball,
-  FaTableTennis,
-  FaBowlingBall,
-  GiShuttlecock,
-  MdSportsTennis,
-} from 'react-icons/all';
-
+import { MdSportsSoccer, MdSportsBaseball, MdSportsBasketball, MdSportsTennis } from 'react-icons/md';
+import { FaTableTennis, FaBowlingBall } from 'react-icons/fa';
+import { GiShuttlecock } from 'react-icons/gi';
 import * as S from './TeamBadge.style';
 import { ColorProps, IconsProps } from './types';
 
@@ -47,7 +40,7 @@ const TeamBadge = ({ teamId, sportsCategory, name }: Props) => (
     >
       <S.BadgeInner>
         <S.IconWrapper>{Icons[sportsCategory]}</S.IconWrapper>
-        <span>{name}</span>
+        <S.BadgeText>{name}</S.BadgeText>
       </S.BadgeInner>
     </Badge>
   </S.TeamBadgeWrapper>

--- a/src/components/TeamBadge/index.ts
+++ b/src/components/TeamBadge/index.ts
@@ -1,0 +1,1 @@
+export { default as TeamBadge } from './TeamBadge';

--- a/src/components/TeamBadge/types.ts
+++ b/src/components/TeamBadge/types.ts
@@ -1,0 +1,7 @@
+export interface IconsProps {
+  [key: string]: JSX.Element;
+}
+
+export interface ColorProps {
+  [key: number]: string;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export { Input } from './Input';
 export { Avatar } from './Avatar';
 export { FilterButton } from './FilterButton';
 export { ReviewGroup } from './ReviewGroup';
+export { TeamBadge } from './TeamBadge';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3359,6 +3359,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
+  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
TeamBadge 컴포넌트 구현했습니다!

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

<img width="371" alt="스크린샷 2022-08-01 오전 4 20 47" src="https://user-images.githubusercontent.com/33307948/182041860-3dd20157-c363-4845-8fc4-79eac69e5b52.png">

- Badge 컴포넌트 사용해서 만들었습니다! @dustmddus 클레어 잘썼어요!
- Badge 컴포넌트에서 children props type에 JSX.Element 속성 or로 추가했습니다.
- teamId를 받아서 color를 다양하게 보이도록 했습니다. 이건 추후 변동이 있을 수 있을 것 같아요. 우선순위에 따라서나 그냥 디자인에서나 바뀌면 바로 수정하도록 하겠습니다.
- Icons는 종목(SportsCategory)에 따라 바뀌도록 했습니다.
- name은 팀명이고 API에서 받은대로 출력할 예정입니다!

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 어제 react-icons 라이브러리 사용에 클레어랑 톰슨에게 동의는 구했는데 papa의 동의는 못구했네요! react-icons에 대해서 의견 부탁드려요! 바꿔도 무방합니다!
- [React Icons](https://react-icons.github.io/react-icons)
