### PR TITLE
[Dk 266] Heading 컴포넌트 구현

### DIFF
--- a/src/components/Heading/Heading.styles.ts
+++ b/src/components/Heading/Heading.styles.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { HeadingTitleProps } from './types';
 
 export const HeadingWrapper = styled.div`
   display: flex;
@@ -8,7 +7,7 @@ export const HeadingWrapper = styled.div`
   padding: 1rem;
 `;
 
-export const HeadingTitle = styled.h1<HeadingTitleProps>`
+export const HeadingTitle = styled.h1`
   font-size: ${(props) => props.theme.fontSize.b1};
   font-weight: bold;
 `;

--- a/src/components/Heading/Heading.styles.ts
+++ b/src/components/Heading/Heading.styles.ts
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+import { HeadingTitleProps } from './types';
+
+export const HeadingWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  height: 70px;
+  padding: 1rem;
+`;
+
+export const HeadingTitle = styled.h1<HeadingTitleProps>`
+  font-size: ${(props) => props.theme.fontSize.b1};
+  font-weight: bold;
+`;

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,20 +1,35 @@
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { MdArrowBackIos } from 'react-icons/md';
 import * as S from './Heading.styles';
-import { noBackIcon, headingTitle } from './types';
+import { HeadingTitleProps } from './types';
+
+export const headingTitle: HeadingTitleProps = {
+  '/signup': '회원가입',
+  '/signin': '로그인',
+  '/town': '내 동네 설정',
+  '/team/create': '팀 생성',
+  '/team/invitation': '팀원 초대',
+  '/alarm': '알림',
+  '/teams/:id': '팀 프로필',
+  '/users/:id': '프로필',
+  '/users/:id/본인': '내 정보',
+  '/': `송파동`,
+  '/post': '글쓰기',
+  '/posts/:id': '상세 페이지',
+  '/matches/:id/result': '경기 결과',
+  '/matches/:id/review': '후기 작성',
+  '/proposals': '신청하기',
+  '/chats': `유저 닉네임`,
+  '/chatList': '채팅',
+};
+
+export const noBackIcon = ['/signup', '/signin', '/', '/matches/:id/review', 'users/:id'];
 
 const Heading = () => {
   const router = useRouter();
   return (
     <S.HeadingWrapper>
-      {!noBackIcon.includes(router.pathname) ? (
-        <Link href='/'>
-          <MdArrowBackIos />
-        </Link>
-      ) : (
-        <div />
-      )}
+      {!noBackIcon.includes(router.pathname) ? <MdArrowBackIos onClick={() => router.back()} /> : <div />}
       <S.HeadingTitle>{headingTitle[router.pathname]}</S.HeadingTitle>
     </S.HeadingWrapper>
   );

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { MdArrowBackIos } from 'react-icons/md';
+import * as S from './Heading.styles';
+import { noBackIcon, headingTitle } from './types';
+
+const Heading = () => {
+  const router = useRouter();
+  return (
+    <S.HeadingWrapper>
+      {!noBackIcon.includes(router.pathname) ? (
+        <Link href='/'>
+          <MdArrowBackIos />
+        </Link>
+      ) : (
+        <div />
+      )}
+      <S.HeadingTitle>{headingTitle[router.pathname]}</S.HeadingTitle>
+    </S.HeadingWrapper>
+  );
+};
+
+export default Heading;

--- a/src/components/Heading/index.ts
+++ b/src/components/Heading/index.ts
@@ -1,0 +1,1 @@
+export { default as Heading } from './Heading';

--- a/src/components/Heading/types.ts
+++ b/src/components/Heading/types.ts
@@ -1,0 +1,25 @@
+export interface HeadingTitleProps {
+  [key: string]: string;
+}
+
+export const headingTitle: HeadingTitleProps = {
+  '/signup': '회원가입',
+  '/signin': '로그인',
+  '/town': '내 동네 설정',
+  '/team/create': '팀 생성',
+  '/invitation': '팀원 초대',
+  '/alarm': '알림',
+  '/teams/:id': '팀 프로필',
+  '/users/:id': '프로필',
+  '/users/:id/본인': '내 정보',
+  '/': `송파동`,
+  '/post': '글쓰기',
+  '/posts/:id': '상세 페이지',
+  '/matches/:id/result': '경기 결과',
+  '/matches/:id/review': '후기 작성',
+  '/proposals': '신청하기',
+  '/chats': `유저 닉네임`,
+  '/chatList': '채팅',
+};
+
+export const noBackIcon = ['/signup', '/signin', '/', '/matches/:id/review', 'users/:id'];

--- a/src/components/Heading/types.ts
+++ b/src/components/Heading/types.ts
@@ -7,7 +7,7 @@ export const headingTitle: HeadingTitleProps = {
   '/signin': '로그인',
   '/town': '내 동네 설정',
   '/team/create': '팀 생성',
-  '/invitation': '팀원 초대',
+  '/team/invitation': '팀원 초대',
   '/alarm': '알림',
   '/teams/:id': '팀 프로필',
   '/users/:id': '프로필',

--- a/src/components/Heading/types.ts
+++ b/src/components/Heading/types.ts
@@ -1,25 +1,3 @@
 export interface HeadingTitleProps {
   [key: string]: string;
 }
-
-export const headingTitle: HeadingTitleProps = {
-  '/signup': '회원가입',
-  '/signin': '로그인',
-  '/town': '내 동네 설정',
-  '/team/create': '팀 생성',
-  '/team/invitation': '팀원 초대',
-  '/alarm': '알림',
-  '/teams/:id': '팀 프로필',
-  '/users/:id': '프로필',
-  '/users/:id/본인': '내 정보',
-  '/': `송파동`,
-  '/post': '글쓰기',
-  '/posts/:id': '상세 페이지',
-  '/matches/:id/result': '경기 결과',
-  '/matches/:id/review': '후기 작성',
-  '/proposals': '신청하기',
-  '/chats': `유저 닉네임`,
-  '/chatList': '채팅',
-};
-
-export const noBackIcon = ['/signup', '/signin', '/', '/matches/:id/review', 'users/:id'];


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Heading 컴포넌트 구현했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
<img width="712" alt="스크린샷 2022-08-02 오후 3 45 46" src="https://user-images.githubusercontent.com/33307948/182310206-88c45ceb-ca62-402d-86d7-7d2c81fbe381.png">

<img width="706" alt="스크린샷 2022-08-02 오후 3 45 32" src="https://user-images.githubusercontent.com/33307948/182310315-a1fff732-ebc1-4a59-a38c-a4ce031a82de.png">

- 해당 url에 맞게 title을 설정했습니다.
- 새 페이지 구성해서 test 해봤습니다!
- 아이콘 뒤로가기를 누르면 router.back()으로 뒤 페이지로 이동합니다.
- 수정사항 있으면 알려주세요!