### PR TITLE
[DK-297] 로그인 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
-    "recoil": "^0.7.4"
+    "recoil": "^0.7.4",
+    "recoil-persist": "^4.2.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.3.1",

--- a/src/components/SignInForm/SignInForm.tsx
+++ b/src/components/SignInForm/SignInForm.tsx
@@ -1,0 +1,75 @@
+import { FormEvent } from 'react';
+import { AxiosError } from 'axios';
+import { useRecoilState } from 'recoil';
+import { axiosAuthInstance } from '@api/axiosInstances';
+import { useForm } from '@hooks/useForm';
+import { useRouter } from 'next/router';
+import { Input } from '@components/Input';
+import { Button } from '@components/Button';
+import { userState } from '@recoil/atoms';
+import { ErrorResponse, Values } from './types';
+import validation from './helper';
+
+const SignInForm = () => {
+  const router = useRouter();
+  const [, setUser] = useRecoilState(userState);
+  const onSubmit = (values: Values, e?: FormEvent<HTMLFormElement>) => {
+    const { username, password } = values;
+    e?.preventDefault();
+    const signin = async () => {
+      try {
+        const res = await axiosAuthInstance({
+          method: 'post',
+          url: '/api/users/signin',
+          data: {
+            username,
+            password,
+          },
+        });
+        if (res.status === 200) {
+          setUser((res.data as { data: object }).data);
+          router.replace('/');
+        }
+      } catch (err) {
+        const { response } = err as AxiosError;
+        if (response) {
+          const errorCode = (response.data as ErrorResponse).code;
+          if (errorCode === 'A0001') {
+            window.alert('아이디 또는 비밀번호가 일치하지 않습니다.');
+          }
+        }
+      }
+    };
+    signin();
+  };
+  const { values, errors, isLoading, handleChange, handleSubmit } = useForm<Values>({
+    initialValue: {
+      username: '',
+      password: '',
+    },
+    onSubmit,
+    validate: validation,
+  });
+  return (
+    <form onSubmit={handleSubmit}>
+      <Input
+        name='username'
+        value={values.username}
+        onChange={handleChange}
+        placeholder='아이디'
+      />
+      <span>{errors.username}</span>
+      <Input
+        type='password'
+        name='password'
+        value={values.password}
+        onChange={handleChange}
+        placeholder='비밀번호'
+      />
+      <span>{errors.password}</span>
+      <Button width='100%'>로그인</Button>
+    </form>
+  );
+};
+
+export default SignInForm;

--- a/src/components/SignInForm/SignInForm.tsx
+++ b/src/components/SignInForm/SignInForm.tsx
@@ -1,6 +1,6 @@
 import { FormEvent } from 'react';
 import { AxiosError } from 'axios';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { axiosAuthInstance } from '@api/axiosInstances';
 import { useForm } from '@hooks/useForm';
 import { useRouter } from 'next/router';
@@ -12,7 +12,7 @@ import validation from './helper';
 
 const SignInForm = () => {
   const router = useRouter();
-  const [, setUser] = useRecoilState(userState);
+  const setUser = useSetRecoilState(userState);
   const onSubmit = (values: Values, e?: FormEvent<HTMLFormElement>) => {
     const { username, password } = values;
     e?.preventDefault();

--- a/src/components/SignInForm/helper.ts
+++ b/src/components/SignInForm/helper.ts
@@ -1,0 +1,24 @@
+import { Values } from './types';
+
+const regexUsername = /^[a-z0-9_]{6,24}$/;
+const regexPassword = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+
+const validation = ({ username, password }: Values) => {
+  const errors: Values = {};
+
+  if (!username) {
+    errors.username = '아이디를 입력해주세요.';
+  } else if (!regexUsername.test(username)) {
+    errors.username = '아이디 형식에 맞지 않습니다. (영문 소문자, 숫자 6자리 이상 24자리 이하)';
+  }
+
+  if (!password) {
+    errors.password = '비밀번호를 입력해주세요.';
+  } else if (!regexPassword.test(password)) {
+    errors.password = '비밀번호 형식에 맞지 않습니다. (영문 소문자, 대문자, 숫자, 특수문자 포함 8자리 이상)';
+  }
+
+  return errors;
+};
+
+export default validation;

--- a/src/components/SignInForm/index.tsx
+++ b/src/components/SignInForm/index.tsx
@@ -1,0 +1,2 @@
+export { default as SignInForm } from './SignInForm';
+export type { Values, SuccessResponse, ErrorResponse } from './types';

--- a/src/components/SignInForm/types.ts
+++ b/src/components/SignInForm/types.ts
@@ -1,0 +1,15 @@
+export interface Values {
+  username?: string;
+  password?: string;
+}
+
+export interface SuccessResponse {
+  id: number;
+  username: string;
+  nickname: string;
+}
+
+export interface ErrorResponse {
+  code: string;
+  message: string;
+}

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,0 +1,5 @@
+import SignInForm from '@components/SignInForm/SignInForm';
+
+const SignIn = () => <SignInForm />;
+
+export default SignIn;

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,0 +1,16 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+
+interface UserState {
+  id?: number;
+  username?: string;
+  nickname?: string;
+}
+
+export const userState = atom<UserState>({
+  key: 'userState',
+  default: {},
+  effects_UNSTABLE: [persistAtom],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3575,6 +3575,11 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+recoil-persist@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-4.2.0.tgz#9fbb4a8c158cbb83ceb9dedf795aee24ed15395d"
+  integrity sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==
+
 recoil@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.4.tgz#d6508fa656d9c93e66fdf334e1f723a9e98801cf"


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
로그인 기능을 구현했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
<img width="303" alt="image" src="https://user-images.githubusercontent.com/61747121/182775034-e5f974c2-e459-4e94-9fc4-32338751e553.png">

fa3ccffc205ddc04637b29658d6b149a5cb2894a 전역 상태 유지를 위해 `recoil-persist` 라이브러리를 설치했습니다.

ec3d3098110cf73fa5157f52478cdcc5af3f58be 로그인 기능을 구현했습니다.

7af4471f0b5788006f2dc8a692d79bfb825153e4 유저 정보를 전역 상태로 추가했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 지금은 로그인 하면 전역 상태에 유저 객체를 저장하고 메인 페이지로 이동합니다. 다른 기능이 필요할까요?!
- 전역으로 관리해야 하는 타입인데 전역에 두는 게 맞는건지 몰라서 일단 현재 위치에 두었습니다. 변경 필요하면 말씀해주세요!
- 그 외 타입스크립트 문제가 있다면 말씀해주세요!
- 코드 문제도 알려주시면 감사하겠습니다!
