### PR TITLE
[DK-339] 공고 신청하기 페이지 UI 구성

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -6,7 +6,7 @@ import { Item } from './types';
 interface Props<T> {
   round?: boolean;
   items: Item<T>[];
-  placeholder: string;
+  placeholder?: string;
   onSelect: (item: Item<T>) => void;
 }
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/md';
-
 import * as S from './Dropdown.styles';
 import { Item } from './types';
 

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -18,7 +18,7 @@ export const headingTitle: HeadingTitleProps = {
   '/posts/[id]': '상세 페이지',
   '/matches/[id]/result': '경기 결과',
   '/matches/[id]/review': '후기 작성',
-  '/proposals': '신청하기',
+  '/matches/[id]/proposal': '신청하기',
   '/chats': `유저 닉네임`,
   '/chat': '채팅',
 };

--- a/src/pages/matches/[id]/index.tsx
+++ b/src/pages/matches/[id]/index.tsx
@@ -1,0 +1,27 @@
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+
+const MatchDetailPage: NextPage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const handleClick = () => {
+    if (id) {
+      router.push(`${id.toString()}/proposal`);
+    }
+  };
+  return (
+    <div style={{ width: '100%', top: '120px' }}>
+      {/* TODO: Rebase 예정 승연님이 구현해둠 */}
+      매치 상세 페이지
+      <button
+        type='button'
+        onClick={handleClick}
+      >
+        신청하기
+      </button>
+    </div>
+  );
+};
+
+export default MatchDetailPage;

--- a/src/pages/matches/[id]/proposal.tsx
+++ b/src/pages/matches/[id]/proposal.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@components/Button';
+import { Dropdown } from '@components/Dropdown';
+import { Container, ColWrapper, TextArea } from '@styles/common';
+import { Team } from 'interface/team';
+import { NextPage } from 'next';
+import { useState } from 'react';
+
+const MyTeamDummy: Team[] = [
+  { id: 1, sportsCategory: 'tableTennis', name: '탁구왕 연승팀' },
+  { id: 2, sportsCategory: 'soccer', name: '축구짱' },
+  { id: 3, sportsCategory: 'baseball', name: '야구짱' },
+];
+
+const TeamChoiceDummy = MyTeamDummy.map((MyTeam) => {
+  const TeamChoice = { id: 0, text: '', value: '' };
+  TeamChoice.id = MyTeam.id;
+  TeamChoice.text = MyTeam.name;
+  TeamChoice.value = MyTeam.id.toString();
+  return TeamChoice;
+});
+
+const Proposal: NextPage = () => {
+  const [proposalData, setProposalData] = useState({ teamId: 0, content: '' });
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setProposalData(() => ({ ...proposalData, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    console.log(proposalData);
+    // TODO: API 연동
+    // (async () => {
+    //   const res = await axiosAuthInstance({
+    //     method: 'POST',
+    //     url: '/api/',
+    //     data: proposalData,
+    //   });
+
+    //   console.log(res);
+    // })();
+  };
+  const handleSelect = (value: string) => {
+    setProposalData({ ...proposalData, teamId: Number(value) });
+  };
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <ColWrapper>
+          <Dropdown
+            dropdownItems={TeamChoiceDummy}
+            onSelect={handleSelect}
+            placeholder='팀 선택'
+          />
+          <TextArea
+            name='content'
+            placeholder='요청 내용을 입력해주세요'
+            onChange={handleChange}
+          />
+          <Button width='100%'>제출</Button>
+        </ColWrapper>
+      </form>
+    </Container>
+  );
+};
+
+export default Proposal;

--- a/src/pages/matches/[id]/proposal.tsx
+++ b/src/pages/matches/[id]/proposal.tsx
@@ -49,8 +49,8 @@ const Proposal: NextPage = () => {
       <form onSubmit={handleSubmit}>
         <ColWrapper>
           <Dropdown
-            dropdownItems={TeamChoiceDummy}
-            onSelect={handleSelect}
+            items={TeamChoiceDummy}
+            onSelect={() => handleSelect}
             placeholder='팀 선택'
           />
           <TextArea


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
공고 신청하기 페이지 UI 구성했습니다!

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
<img width="381" alt="스크린샷 2022-08-05 오전 2 06 11" src="https://user-images.githubusercontent.com/33307948/182911270-15ae444c-f7c8-426d-8af8-fd67303d7648.png">

- matches/[id]/index.tsx로 구성했습니다. 이 페이지는 승연님이 만들어 두셔서 추후 리베이스 하겠습니다.
- matches/[id]/proposal로 라우팅했습니다.
- dropdown에 placeholder 추가했습니다.
- 작업하면서 heading routing 수정하고 있습니다.