### PR TITLE
[DK-299] 공고 조회 API 연동 테스트

### DIFF
--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -1,0 +1,38 @@
+import { axiosAuthInstance } from '@api/axiosInstances';
+import { getCategoricalMatches } from '@recoil/match';
+import { useEffect, useState } from 'react';
+import { useRecoilValueLoadable } from 'recoil';
+
+const MatchList = () => {
+  const matches = useRecoilValueLoadable(getCategoricalMatches);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const handleLogin = () => {
+    axiosAuthInstance({
+      method: 'POST',
+      url: '/api/users/signin',
+      data: {
+        username: 'test12',
+        password: 'Qwer1234!',
+      },
+    });
+  };
+
+  useEffect(() => {
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <div>
+      <button
+        type='button'
+        onClick={handleLogin}
+      >
+        로그인
+      </button>
+      {!isLoading ? <div>{JSON.stringify(matches)}</div> : <div>loading</div>}
+    </div>
+  );
+};
+
+export default MatchList;

--- a/src/recoil/match.ts
+++ b/src/recoil/match.ts
@@ -1,0 +1,46 @@
+import { axiosAuthInstance } from '@api/axiosInstances';
+import { atom, selector } from 'recoil';
+
+export const matchesState = atom({
+  key: 'matchesCategory',
+  default: '',
+});
+
+export const getCategoricalMatches = selector({
+  key: 'get/categorical-matches',
+  get: async ({ get }) => {
+    const category = get(matchesState);
+    console.log(category);
+    if (category === '') {
+      try {
+        const res = await axiosAuthInstance.get('/api/matches', {
+          params: {
+            size: 10,
+            status: 'WAITING',
+            distance: 30,
+          },
+        });
+        return (res.data as { data: object }).data;
+      } catch (err) {
+        throw new Error(`${err as string}`);
+      }
+    }
+    try {
+      const res = await axiosAuthInstance.get('/api/matches', {
+        params: {
+          size: 10,
+          category,
+          status: 'WAITING',
+          distance: 30,
+          validCursor: true,
+        },
+      });
+      return (res.data as { data: object }).data;
+    } catch (err) {
+      throw new Error(`${err as string}`);
+    }
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: 'most-recent',
+  },
+});


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
공고 조희 API를 연동했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
공고를 조회할 수 있습니다.
`/test` 페이지로 들어가서 먼저 로그인 버튼을 눌러 로그인하고,
해당 페이지 새로고침하면 데이터가 보입니다!

cd51100bbc978a08f8181f9aa42a365df141997c 공고 조회를 위한 전역 상태를 만들었습니다!

d55a16ced15a997b86071fad9d5584ca598a1d84 지금은 메인 영역이 헤더에 가려져서 안보이길래 임시로 inline 스타일 추가했습니다.

17cff3c5f95305f751c091334f82414ac21718c3 테스트를 위한 페이지를 추가했습니다.