### PR TITLE
[DK-289] 개인 프로필 API 연동

### DIFF
--- a/src/components/TeamBadge/TeamBadge.tsx
+++ b/src/components/TeamBadge/TeamBadge.tsx
@@ -6,7 +6,6 @@ import * as S from './TeamBadge.styles';
 import { ColorProps, IconsProps } from './types';
 
 interface Props {
-  teamId: number;
   sportsCategory: string;
   name: string;
 }
@@ -21,19 +20,19 @@ const Color: ColorProps = {
 };
 
 const Icons: IconsProps = {
-  soccer: <MdSportsSoccer size='21px' />,
-  baseball: <MdSportsBaseball size='21px' />,
-  basketball: <MdSportsBasketball size='21px' />,
-  tableTennis: <FaTableTennis size='21px' />,
-  bowling: <FaBowlingBall size='21px' />,
-  badminton: <GiShuttlecock size='21px' />,
-  tennis: <MdSportsTennis size='21px' />,
+  SOCCER: <MdSportsSoccer size='21px' />,
+  BASEBALL: <MdSportsBaseball size='21px' />,
+  BASKETBALL: <MdSportsBasketball size='21px' />,
+  TABLETENNIS: <FaTableTennis size='21px' />,
+  BOWLING: <FaBowlingBall size='21px' />,
+  BADMINTON: <GiShuttlecock size='21px' />,
+  TENNIS: <MdSportsTennis size='21px' />,
 };
 
-const TeamBadge = ({ teamId, sportsCategory, name }: Props) => (
+const TeamBadge = ({ sportsCategory, name }: Props) => (
   <S.TeamBadgeWrapper>
     <Badge
-      color={Color[teamId]}
+      color={Color[Math.floor(Math.random() * 6 + 1)]}
       width='100%'
       height='38px'
       borderRadius='5px'

--- a/src/interface/response.ts
+++ b/src/interface/response.ts
@@ -1,0 +1,3 @@
+export interface Response<T> {
+  data: T;
+}

--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -1,86 +1,97 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { NextPage } from 'next';
+import React from 'react';
+
+import { axiosAuthInstance } from '@api/axiosInstances';
 import { Avatar } from '@components/Avatar';
 import { Divider } from '@components/Divider';
 import { ReviewGroup } from '@components/ReviewGroup';
 import { TeamBadge } from '@components/TeamBadge';
 import { B1, B2, ColWrapper, Container, GrayB3, InnerWrapper, Label, ResetBtn, RowWrapper } from '@styles/common';
-import { Team } from 'interface/team';
-import { UserInfo } from 'interface/user';
-import { NextPage } from 'next';
-import Link from 'next/link';
+import { Team } from '@interface/team';
+import { UserInfo } from '@interface/user';
+import { Response } from '@interface/response';
 
-const DummyData: UserInfo = {
-  nickname: '규범장',
-  review: {
-    bestCount: 3,
-    likeCount: 1,
-    dislikeCount: 2,
-  },
-  location: {
-    longitude: '1',
-    latitude: '1',
-  },
-  teams: [
-    {
-      id: 1,
-      name: '이 구역 테니스 짱',
-      sportsCategory: 'tennis',
+const UserDetailPage: NextPage = () => {
+  const router = useRouter();
+
+  const [userInfo, setUserInfo] = React.useState<UserInfo>({
+    nickname: '',
+    review: {
+      bestCount: 0,
+      likeCount: 0,
+      dislikeCount: 0,
     },
-    { id: 2, sportsCategory: 'soccer', name: '축구짱' },
-    { id: 3, sportsCategory: 'baseball', name: '야구킹킹' },
-    { id: 4, sportsCategory: 'tableTennis', name: '탁구왕들의 모임' },
-  ],
-};
+    location: {
+      longitude: '',
+      latitude: '',
+    },
+    teams: [],
+  });
 
-const UserDetailPage: NextPage = () => (
-  <Container>
-    <RowWrapper>
-      <Avatar />
-      <InnerWrapper
-        flexDirection='column'
-        justifyContent='center'
-        margin='0px 16px'
-      >
-        <B1>{DummyData.nickname}</B1>
-        {/* TODO: 위도 경도 기반 지역구 출력 */}
-        <GrayB3>송파구</GrayB3>
-      </InnerWrapper>
-    </RowWrapper>
-    <Divider />
-    <ColWrapper>
-      <Label>나에 대한 후기</Label>
-      <ReviewGroup
-        bestCount={3}
-        likeCount={1}
-        dislikeCount={2}
-      />
-    </ColWrapper>
-    <Divider />
-    <ColWrapper>
-      <Label>내 팀 목록</Label>
-      <div>
-        {DummyData.teams.map((team: Team) => (
-          <TeamBadge
-            teamId={team.id}
-            sportsCategory={team.sportsCategory}
-            name={team.name}
-            key={team.id}
-          />
-        ))}
-      </div>
-    </ColWrapper>
-    {/* TODO: 조건부 렌더링 처리: 로그인 사용자 닉네임이 같은 경우 출력하도록 수정 필요 */}
-    <Divider />
-    <ColWrapper>
-      <Label>나의 활동</Label>
+  React.useEffect(() => {
+    if (!router.isReady) return;
+
+    (async () => {
+      const {
+        data: { data },
+      } = await axiosAuthInstance.get<Response<UserInfo>>(`/api/users/${router.query.id as string}`);
+
+      setUserInfo(() => data);
+    })();
+  }, [router.isReady]);
+
+  return (
+    <Container>
+      <RowWrapper>
+        <Avatar />
+        <InnerWrapper
+          flexDirection='column'
+          justifyContent='center'
+          margin='0px 16px'
+        >
+          <B1>{userInfo.nickname}</B1>
+          {/* TODO: 위도 경도 기반 지역구 출력 */}
+          <GrayB3>송파구</GrayB3>
+        </InnerWrapper>
+      </RowWrapper>
+      <Divider />
       <ColWrapper>
-        <Link href='/town'>
-          <B2>내 동네 설정하기</B2>
-        </Link>
-        {/* TODO: onClick 이벤트로 로그아웃 API 호출 */}
-        <ResetBtn type='button'>로그아웃</ResetBtn>
+        <Label>나에 대한 후기</Label>
+        <ReviewGroup
+          bestCount={userInfo.review.bestCount}
+          likeCount={userInfo.review.likeCount}
+          dislikeCount={userInfo.review.dislikeCount}
+        />
       </ColWrapper>
-    </ColWrapper>
-  </Container>
-);
+      <Divider />
+      <ColWrapper>
+        <Label>내 팀 목록</Label>
+        <div>
+          {userInfo.teams.map((team: Team) => (
+            <TeamBadge
+              sportsCategory={team.sportsCategory}
+              name={team.name}
+              key={team.id}
+            />
+          ))}
+        </div>
+      </ColWrapper>
+      {/* TODO: 조건부 렌더링 처리: 로그인 사용자 닉네임이 같은 경우 출력하도록 수정 필요 */}
+      <Divider />
+      <ColWrapper>
+        <Label>나의 활동</Label>
+        <ColWrapper>
+          <Link href='/user/[id]/location'>
+            <B2>내 동네 설정하기</B2>
+          </Link>
+          {/* TODO: onClick 이벤트로 로그아웃 API 호출 */}
+          <ResetBtn type='button'>로그아웃</ResetBtn>
+        </ColWrapper>
+      </ColWrapper>
+    </Container>
+  );
+};
 
 export default UserDetailPage;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
       "@components/*": ["components/*"],
       "@constants/*": ["constants/*"],
       "@hooks/*": ["hooks/*"],
+      "@interface/*": ["interface/*"],
       "@pages/*": ["pages/*"],
       "@recoil/*": ["recoil/*"],
       "@styles/*": ["styles/*"],


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

- 개인 프로필 API 연동했습니다

![image](https://user-images.githubusercontent.com/39076382/183098684-88d61f18-6341-475a-a7f7-25c174cdd2ec.png)


## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

c07b1fb714807688c1e992a3640a82407e863427
인터페이스 폴더를 유지해야 할 것 같아요
`@types` 폴더에서 import 에러가 발생합니다

2e2cd3568b0c2b498ac5c0d6169c7237000bc7aa
비동기 요청 시에 공통적으로 쓸 수 있는 response 객체를 정의해두었습니다

dbf2b95aa24bd2bdcda75ec742901431b776fe23
종목에 대한 정보가 UpperCase라 Icon의 프로퍼티 또한 변경했습니다

36a88cfb0a5efd567bdea71fd8145f44eb1a422d
API 연동 작업했습니다

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- 위치 정보를 기반으로 주소로 변환하는 기능구현은 DK-291에서 할 예정입니다
- 링크 관련 기능도 DK-291에 반영할 예정입니다