### PR TITLE
[DK-297] 로그인 기능 구현 (로그인 상태에 따른 흐름 정리)

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useRouter } from 'next/router';
 
@@ -15,15 +15,25 @@ interface Props {
 const Layout = ({ children }: Props) => {
   const router = useRouter();
   const user = useRecoilValue(userState);
+  const [isLoading, setIsLoading] = React.useState(true);
 
   useEffect(() => {
-    if (!publicPath.includes(router.pathname) && user.id === undefined) {
-      router.replace('/');
-    } else if (publicPath.includes(router.pathname) && user.id !== undefined) {
-      router.back();
-    }
+    const test = async () => {
+      if (!publicPath.includes(router.pathname) && user.id === undefined) {
+        await router.replace('/');
+      } else if (publicPath.includes(router.pathname) && user.id !== undefined) {
+        await new Promise(() => {
+          router.back();
+        });
+      }
+    };
+    (async () => {
+      await test();
+      setIsLoading(false);
+    })();
   }, [router.pathname]);
 
+  if (isLoading) return null;
   if (router.pathname === '/') {
     return <Main>{children}</Main>;
   }

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,8 +1,12 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/router';
+
 import { Heading } from '@components/Heading';
 import { Navigator } from '@components/Navigator';
-import { useRouter } from 'next/router';
 import { Main } from '@styles/common';
+import { userState } from '@recoil/atoms';
+import { publicPath } from '@constants/publicPath';
 
 interface Props {
   children: ReactNode;
@@ -10,6 +14,16 @@ interface Props {
 
 const Layout = ({ children }: Props) => {
   const router = useRouter();
+  const user = useRecoilValue(userState);
+
+  useEffect(() => {
+    if (!publicPath.includes(router.pathname) && user.id === undefined) {
+      router.replace('/');
+    } else if (publicPath.includes(router.pathname) && user.id !== undefined) {
+      router.back();
+    }
+  }, [router.pathname]);
+
   if (router.pathname === '/') {
     return <Main>{children}</Main>;
   }

--- a/src/components/SignInForm/SignInForm.tsx
+++ b/src/components/SignInForm/SignInForm.tsx
@@ -15,6 +15,7 @@ import validation from './helper';
 const SignInForm = () => {
   const router = useRouter();
   const setUser = useSetRecoilState(userState);
+
   const onSubmit = (values: Values, e?: FormEvent<HTMLFormElement>) => {
     const { username, password } = values;
     e?.preventDefault();
@@ -30,7 +31,7 @@ const SignInForm = () => {
         });
         if (res.status === 200) {
           setUser((res.data as { data: object }).data);
-          router.replace('/');
+          router.replace('/matches');
         }
       } catch (err) {
         const { response } = err as AxiosError;

--- a/src/components/SignUpForm/SignUpForm.tsx
+++ b/src/components/SignUpForm/SignUpForm.tsx
@@ -1,11 +1,13 @@
 import { FormEvent, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+
 import { axiosDefaultInstance } from '@api/axiosInstances';
 import { Button } from '@components/Button';
 import { Input } from '@components/Input';
 import { useForm } from '@hooks/useForm';
 import { B3, ColWrapper, Container, InnerWrapper } from '@styles/common';
+
 import { ErrorText, StrongText } from './SignUpForm.styles';
 import validation from './helper';
 import { Values } from './types';
@@ -13,6 +15,7 @@ import { Values } from './types';
 const SignUpForm = () => {
   const router = useRouter();
   const [checked, setChecked] = useState(false);
+
   const onSubmit = (values: Values, e?: FormEvent<HTMLFormElement>) => {
     const { username, nickname, password } = values;
     e?.preventDefault();

--- a/src/components/Welcome/Welcome.tsx
+++ b/src/components/Welcome/Welcome.tsx
@@ -29,6 +29,16 @@ const Welcome = () => (
           <Button width='300px'>시작하기</Button>
         </InnerWrapper>
       </Link>
+
+      <S.Info>
+        이미 계정이 있으신가요?
+        <Link
+          href='/signin'
+          passHref
+        >
+          <S.Login> 로그인하기</S.Login>
+        </Link>
+      </S.Info>
     </S.ButtonContainer>
     <S.Info>
       <B3>이미 계정이 있으신가요?</B3>

--- a/src/constants/publicPath.ts
+++ b/src/constants/publicPath.ts
@@ -1,0 +1,1 @@
+export const publicPath: string[] = ['/', '/signin', '/signup'];


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
로그인 흐름을 정리했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 로그인 된 사용자
  시작 페이지, 로그인, 회원가입 페이지에 접근할 수 없습니다.
- 로그인 되지 않은 사용자
  시작 페이지, 로그인, 회원가입 페이지를 제외한 모든 페이지에 접근할 수 없습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 서버 사이드에서 로그인 상태 파악하고 리다이렉트 된 페이지를 보여주면 좋겠지만, 방법을 몰라서 useEffect 사용했습니다! 그래서 일단 페이지 렌더링을 한 후, 로그인 상태에 따라 리다이렉트 하기 때문에 사용자 경험은 좋지 않습니다. 이건 나중에 해결해보는걸로
