### PR TITLE
[DK-295] 팀 프로필 기능 구현

### DIFF
--- a/src/components/TeamBadge/TeamBadge.tsx
+++ b/src/components/TeamBadge/TeamBadge.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 import { Badge } from '@components/Badge';
 import { SportsIcon } from '@components/SportsIcon';
 import { Team } from '@interface/team';
 
-import { useRouter } from 'next/router';
 import * as S from './TeamBadge.styles';
 import { ColorProps } from './types';
 

--- a/src/components/TeamBadge/TeamBadge.tsx
+++ b/src/components/TeamBadge/TeamBadge.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@components/Badge';
 import { SportsIcon } from '@components/SportsIcon';
 import { Team } from '@interface/team';
 
+import { useRouter } from 'next/router';
 import * as S from './TeamBadge.styles';
 import { ColorProps } from './types';
 

--- a/src/interface/styles.ts
+++ b/src/interface/styles.ts
@@ -8,3 +8,7 @@ export interface WrapperProps {
   height?: string;
   gap?: string;
 }
+
+export interface OptionalRenderProps {
+  condition: boolean;
+}

--- a/src/interface/team.ts
+++ b/src/interface/team.ts
@@ -17,9 +17,20 @@ export interface MatchRecord {
   draw: number;
   lose: number;
 }
+
+export interface LeaderInfo {
+  id?: number;
+  location?: {
+    longitude: string;
+    latitude: string;
+  };
+  nickname?: string;
+  username?: string;
+}
 export interface TeamInfo {
   name: string;
   description: string;
+  leader: LeaderInfo;
   sportsCategory: string;
   members: MemberInfo[];
   matchRecord: MatchRecord;

--- a/src/pages/team/[id].tsx
+++ b/src/pages/team/[id].tsx
@@ -1,9 +1,12 @@
 import { NextPage } from 'next';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { axiosAuthInstance } from '@api/axiosInstances';
 import { Avatar } from '@components/Avatar';
+import { Button } from '@components/Button';
 import { Divider } from '@components/Divider';
 import { MatchRecordChart } from '@components/MatchRecordChart';
 import { Paragraph } from '@components/Paragraph';
@@ -13,11 +16,8 @@ import { TeamMember } from '@components/TeamMember';
 import { SPORTS_TEXT } from '@constants/text';
 import { Response } from '@interface/response';
 import { TeamInfo } from '@interface/team';
-import { Anchor, B1, B3, ColWrapper, Container, GrayB3, InnerWrapper, Label, RowWrapper } from '@styles/common';
-import { useRecoilValue } from 'recoil';
 import { userState } from '@recoil/atoms';
-import { Button } from '@components/Button';
-import Link from 'next/link';
+import { Anchor, B1, B3, ColWrapper, Container, GrayB3, InnerWrapper, Label, RowWrapper } from '@styles/common';
 
 const TeamDetailPage: NextPage = () => {
   const router = useRouter();

--- a/src/pages/team/[id].tsx
+++ b/src/pages/team/[id].tsx
@@ -13,10 +13,11 @@ import { TeamMember } from '@components/TeamMember';
 import { SPORTS_TEXT } from '@constants/text';
 import { Response } from '@interface/response';
 import { TeamInfo } from '@interface/team';
-import { B1, B3, ColWrapper, Container, GrayB3, InnerWrapper, Label, RowWrapper } from '@styles/common';
+import { Anchor, B1, B3, ColWrapper, Container, GrayB3, InnerWrapper, Label, RowWrapper } from '@styles/common';
 import { useRecoilValue } from 'recoil';
 import { userState } from '@recoil/atoms';
 import { Button } from '@components/Button';
+import Link from 'next/link';
 
 const TeamDetailPage: NextPage = () => {
   const router = useRouter();
@@ -99,16 +100,23 @@ const TeamDetailPage: NextPage = () => {
         <RowWrapper>
           <InnerWrapper alignItems='center'>
             <Label>팀원 목록</Label>
-            <OptionalRender condition={isLeader}>
-              <Button
-                width='24px'
-                height='24px'
-                round
-                onClick={handleClick}
+            {isLeader && (
+              <Link
+                href='/team/invitation'
+                passHref
               >
-                +
-              </Button>
-            </OptionalRender>
+                <Anchor>
+                  <Button
+                    width='24px'
+                    height='24px'
+                    round
+                    onClick={handleClick}
+                  >
+                    +
+                  </Button>
+                </Anchor>
+              </Link>
+            )}
           </InnerWrapper>
         </RowWrapper>
         <ColWrapper gap='16px'>

--- a/src/pages/team/[id].tsx
+++ b/src/pages/team/[id].tsx
@@ -14,14 +14,19 @@ import { SPORTS_TEXT } from '@constants/text';
 import { Response } from '@interface/response';
 import { TeamInfo } from '@interface/team';
 import { B1, B3, ColWrapper, Container, GrayB3, InnerWrapper, Label, RowWrapper } from '@styles/common';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@recoil/atoms';
+import { Button } from '@components/Button';
 
 const TeamDetailPage: NextPage = () => {
   const router = useRouter();
+  const user = useRecoilValue(userState);
 
   const [teamInfo, setTeamInfo] = React.useState<TeamInfo>({
     name: '',
     description: '',
     sportsCategory: '',
+    leader: {},
     members: [],
     matchRecord: {
       win: 0,
@@ -34,6 +39,7 @@ const TeamDetailPage: NextPage = () => {
       dislikeCount: 0,
     },
   });
+  const [isLeader, setIsLeader] = React.useState(false);
 
   React.useEffect(() => {
     if (!router.isReady) return;
@@ -45,8 +51,15 @@ const TeamDetailPage: NextPage = () => {
       } = await axiosAuthInstance.get<Response<TeamInfo>>(`/api/teams/${id as string}`);
 
       setTeamInfo(() => data);
+      if (data.leader.id === user.id) {
+        setIsLeader(true);
+      }
     })();
   }, [router.isReady]);
+
+  const handleClick = () => {
+    router.push('/team/invitation');
+  };
 
   return (
     <Container>
@@ -86,7 +99,16 @@ const TeamDetailPage: NextPage = () => {
         <RowWrapper>
           <InnerWrapper alignItems='center'>
             <Label>팀원 목록</Label>
-            {/* TODO: 로그인 유저와 팀의 리더가 일치할 때 보여질 버튼 링크 */}
+            <OptionalRender condition={isLeader}>
+              <Button
+                width='24px'
+                height='24px'
+                round
+                onClick={handleClick}
+              >
+                +
+              </Button>
+            </OptionalRender>
           </InnerWrapper>
         </RowWrapper>
         <ColWrapper gap='16px'>

--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -78,7 +78,6 @@ const UserDetailPage: NextPage = () => {
             <TeamBadge
               team={team}
               key={team.id}
-              id={team.id}
             />
           ))}
         </div>

--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -78,6 +78,7 @@ const UserDetailPage: NextPage = () => {
             <TeamBadge
               team={team}
               key={team.id}
+              id={team.id}
             />
           ))}
         </div>


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
팀 프로필 기능 구현했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- a5c06b6c011fa679ec2d4f0bbc3a15d4d639dc45 팀 프로필 페이지에서 팀 리더인지 확인 후 팀 리더일 경우 팀원 목록 옆에 팀원 추가 버튼을 렌더링합니다. 조건부 렌더링을 위한 `OptionalRender` 컴포넌트를 만들었습니다.
- a5c06b6c011fa679ec2d4f0bbc3a15d4d639dc45 TeamBadge 컴포넌트에 클릭 이벤트가 없어서 추가했습니다!
