### PR TITLE
[DK-396] 페이지 접근 버그 수정

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -23,7 +23,14 @@ const Layout = ({ children }: Props) => {
         await router.replace('/');
       } else if (publicPath.includes(router.pathname) && user.id !== undefined) {
         await new Promise(() => {
-          router.back();
+          if (
+            document.referrer &&
+            (document.referrer.indexOf('dongkyurami.link') !== -1 || document.referrer.indexOf('localhost'))
+          ) {
+            router.back();
+          } else {
+            router.replace('/matches');
+          }
         });
       }
     };


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
로그인 된 상태로 외부에서 페이지 접근 할 때나 특정 조건 (뭔지는 모름...) 에서 빈 페이지만 출력되던 버그를 수정했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
629cf02d2d139e7f1bdf4f40b240078894759dfb `document.referrer` 를 사용해 히스토리가 있는지 없는지 판단해서 있으면 뒤로 가고, 없으면 `/matches`로 가도록 했습니다!

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 코드는 간단해서 의도한 대로 동작하는지 확인해주시면 감사하겠습니다! 외부에서 (슬랙이나 디코 등) localhost:3000 링크 걸고 테스트 해보시면 될 것 같습니다! 도메인이 다른 페이지 (naver.com, kakao.com 등) 에서 링크로 접근하는 경우도 `/matches` 로 이동하도록 했습니다!
