### PR TITLE
[DK-436] 위치 설정 페이지 기능 수정

### DIFF
--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -6,6 +6,7 @@ export interface StyleProps {
   fontSize: string;
   backgroundColor?: string;
   round?: boolean;
+  disabled?: boolean;
 }
 
 export const Button = styled('button')<StyleProps>(
@@ -18,11 +19,11 @@ export const Button = styled('button')<StyleProps>(
     fontWeight: 600,
     color: '#fff',
   },
-  ({ theme, width, height, fontSize, backgroundColor, round }) => ({
+  ({ theme, width, height, fontSize, backgroundColor, round, disabled }) => ({
     width,
     height,
     fontSize,
     borderRadius: round ? 24 : theme.borderRadius,
-    backgroundColor: backgroundColor || theme.color.secondary,
+    backgroundColor: disabled ? theme.color.gray200 : backgroundColor || theme.color.secondary,
   }),
 );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,6 +16,7 @@ const Button = ({
   round,
   onClick,
   children,
+  disabled = false,
 }: Props) => (
   <S.Button
     backgroundColor={backgroundColor}
@@ -25,6 +26,7 @@ const Button = ({
     onClick={onClick}
     round={round}
     type={type}
+    disabled={disabled}
   >
     {children}
   </S.Button>

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,12 +1,13 @@
-import { ChangeEvent, Dispatch, SetStateAction } from 'react';
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useRef } from 'react';
 
 import * as S from './Slider.styles';
 
 interface Props {
   setDistance: Dispatch<SetStateAction<number>>;
+  distance: number;
 }
 
-const Slider = ({ setDistance }: Props) => {
+const Slider = ({ distance, setDistance }: Props) => {
   const [min, max] = [5, 40];
   const width = 388;
   const step = 5;
@@ -20,13 +21,21 @@ const Slider = ({ setDistance }: Props) => {
     { id: 7, value: 35 },
     { id: 8, value: 40 },
   ];
+  const ref = useRef<HTMLInputElement>(null);
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setDistance(e.target.valueAsNumber);
   };
 
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.valueAsNumber = distance;
+    }
+  });
+
   return (
     <S.Container>
       <S.RangeInput
+        ref={ref}
         type='range'
         width={width}
         min={min}

--- a/src/pages/user/[id]/location.tsx
+++ b/src/pages/user/[id]/location.tsx
@@ -14,7 +14,7 @@ import { B2, B3, BoldB2, ColWrapper, Container, GrayB2, InnerWrapper } from '@st
 const LocationSetting: NextPage = () => {
   const [loginUser, setLoginUser] = useRecoilState(userState);
   const [distance, setDistance] = useState(5);
-  const [kakaoLoading, setKakaoLoading] = useState<boolean>(false);
+  const [kakaoLoading, setKakaoLoading] = useState<boolean>(true);
   const [address, setAddress] = useState<Address>({
     address_name: '',
     region_1depth_name: '',
@@ -36,6 +36,7 @@ const LocationSetting: NextPage = () => {
       }
     }
     fetchAddress();
+    setDistance(loginUser.searchDistance as number);
   }, [geolocation.latitude, geolocation.longitude]);
 
   const handleClick = () => {
@@ -80,9 +81,17 @@ const LocationSetting: NextPage = () => {
           <B2>현 위치를 기준으로</B2>
           <B2>매칭 가능한 거리를 설정해주세요</B2>
         </ColWrapper>
-        <Slider setDistance={setDistance} />
+        <Slider
+          setDistance={setDistance}
+          distance={distance}
+        />
         <InnerWrapper padding='24px 0'>
-          <Button onClick={handleClick}>설정 완료</Button>
+          <Button
+            onClick={handleClick}
+            disabled={kakaoLoading}
+          >
+            설정 완료
+          </Button>
         </InnerWrapper>
       </ColWrapper>
     </Container>


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
위치 설정 페이지에 사용자가 이전에 설정한 거리값을 표시하도록 했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 93075639a103091171acac37a857572c8256d28c 위치 설정 페이지에 사용자가 이전에 설정한 거리값을 표시하도록 했습니다.
- 4e3090498856c5fe3ea1dbfaf2cfcd3d121e83cc 카카오 API가 주소 변환하는 동안은 위치, 거리 설정을 완료할 수 없기 때문에 버튼에 disabled 속성을 추가하고 사용했습니다.
