### PR TITLE
[DK-439] 공고 상세 페이지 1차 버그 픽스

### DIFF
--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -7,18 +7,18 @@ interface Props {
   height: string;
   fontSize: string;
   fontColor: string;
-  borderRadius: string;
+  padding?: boolean;
 }
 
-export const Container = styled.div<Props>`
+export const Container = styled.span<Props>`
   display: flex;
   justify-content: center;
   align-items: center;
-  border-radius: 1rem;
+  padding: ${({ padding }) => padding && '0 12px'};
   width: ${({ width }) => width};
   height: ${({ height }) => height};
   font-size: ${({ fontSize }) => fontSize};
-  border-radius: ${({ borderRadius }) => borderRadius};
+  border-radius: ${({ theme }) => theme.borderRadius};
   color: ${({ fontColor, theme }) => (fontColor === 'primary' ? `${theme.color.background}` : fontColor)};
   background-color: ${({ color, theme, matchType }) => {
     if (matchType) {

--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -24,6 +24,9 @@ export const Container = styled.div<Props>`
     if (matchType) {
       return matchType === 'TEAM_MATCH' ? theme.color.primary : theme.color.yellow;
     }
-    return color === 'primary' ? `${theme.color.green200}` : color;
+
+    if (color === 'primary') return `${theme.color.green200}`;
+    if (color === 'secondary') return `${theme.color.secondary}`;
+    return color;
   }};
 `;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,18 +7,18 @@ interface Props {
   height?: string;
   fontSize?: string;
   fontColor?: string;
-  borderRadius?: string;
+  padding?: boolean;
   children?: string | JSX.Element;
 }
 
 const Badge = ({
   matchType,
   color = 'primary',
-  width = '60px',
-  height = '18px',
+  width = '64px',
+  height = '20px',
   fontSize = '12px',
   fontColor = 'primary',
-  borderRadius = '1rem',
+  padding,
   children,
 }: Props) => (
   <S.Container
@@ -28,7 +28,7 @@ const Badge = ({
     height={height}
     fontSize={fontSize}
     fontColor={fontColor}
-    borderRadius={borderRadius}
+    padding={padding}
   >
     {children}
   </S.Container>

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -19,11 +19,22 @@ export const Button = styled('button')<StyleProps>(
     fontWeight: 600,
     color: '#fff',
   },
-  ({ theme, width, height, fontSize, backgroundColor, round, disabled }) => ({
-    width,
-    height,
-    fontSize,
-    borderRadius: round ? 24 : theme.borderRadius,
-    backgroundColor: disabled ? theme.color.gray200 : backgroundColor || theme.color.secondary,
-  }),
+  ({ theme, width, height, fontSize, backgroundColor, round, disabled }) => {
+    const getColor = () => {
+      if (disabled) return theme.color.gray200;
+      // FIXME: 컬러가 아닌 테마로(불린 값)으로 변경
+      if (backgroundColor === 'primary') return theme.color.primary;
+      if (backgroundColor === 'yellow') return theme.color.yellow;
+      if (backgroundColor) return backgroundColor;
+      return theme.color.secondary;
+    };
+
+    return {
+      width,
+      height,
+      fontSize,
+      borderRadius: round ? 24 : theme.borderRadius,
+      backgroundColor: getColor(),
+    };
+  },
 );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ interface Props extends Partial<S.StyleProps> {
 const Button = ({
   type,
   width = '100%',
-  height = '50px',
+  height = '40px',
   fontSize = '20px',
   backgroundColor,
   round,

--- a/src/components/Dropdown/Dropdown.styles.ts
+++ b/src/components/Dropdown/Dropdown.styles.ts
@@ -20,10 +20,11 @@ export const SelectedItem = styled('div')(
 
 export const RoundSelectedItem = styled(SelectedItem)(
   {
+    height: '32px',
     color: '#fff',
     border: 'none',
-    borderRadius: '24px',
-    padding: '6px 12px',
+    borderRadius: '8px',
+    padding: '0 6px 0 12px',
   },
   ({ theme }) => ({
     backgroundColor: theme.color.secondary,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -14,12 +14,15 @@ interface Props<T> {
 
 export const Dropdown = <T,>({ items, placeholder, onSelect, round, disabled }: Props<T>) => {
   const ref = React.useRef<HTMLDivElement>(null);
+  const toggleRef = React.useRef<HTMLDivElement>(null);
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [text, setText] = React.useState('');
 
+  // FIXME: 드롭다운 닫힌 상태에서 아이콘 클릭 시 작동 안 함
   const handleClickToggle = () => {
     if (disabled) return;
+    // console.log(e.target.closest('div') === toggleRef.current); // true all
     setIsOpen((prev) => !prev);
   };
 
@@ -49,12 +52,18 @@ export const Dropdown = <T,>({ items, placeholder, onSelect, round, disabled }: 
   return (
     <S.Wrapper ref={ref}>
       {round ? (
-        <S.RoundSelectedItem onClick={handleClickToggle}>
+        <S.RoundSelectedItem
+          onClick={handleClickToggle}
+          ref={toggleRef}
+        >
           {text ? <S.TextWhite>{text}</S.TextWhite> : <S.TextWhite>{placeholder}</S.TextWhite>}
           {isOpen ? <MdKeyboardArrowUp size={20} /> : <MdKeyboardArrowDown size={20} />}
         </S.RoundSelectedItem>
       ) : (
-        <S.SelectedItem onClick={handleClickToggle}>
+        <S.SelectedItem
+          onClick={handleClickToggle}
+          ref={toggleRef}
+        >
           {text ? <S.Text>{text}</S.Text> : <S.TextGray>{placeholder}</S.TextGray>}
           {isOpen ? <MdKeyboardArrowUp size={20} /> : <MdKeyboardArrowDown size={20} />}
         </S.SelectedItem>

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -65,7 +65,10 @@ const Heading = () => {
   }, [router.pathname]);
   return (
     <S.HeadingContainer>
-      <RowWrapper>
+      <RowWrapper
+        alignItems='center'
+        gap='4px'
+      >
         {!noBackIcon.includes(router.pathname) ? <MdArrowBackIos onClick={() => router.back()} /> : <div />}
         <Link href={`/user/${user.id?.toString() as string}/location`}>
           <S.HeadingTitle>

--- a/src/components/MatchDetail/MatchDetail.styles.ts
+++ b/src/components/MatchDetail/MatchDetail.styles.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { Button } from '@components/Button/Button.styles';
+
 export const Container = styled.div`
   padding: 16px 24px;
 `;
@@ -30,10 +32,10 @@ export const DetailTitle = styled.span`
   font-size: 16px;
 `;
 
-export const Content = styled.div``;
+export const RefuseButton = styled(Button)`
+  background-color: ${({ theme }) => theme.color.primary};
+`;
 
-export const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  margin: 0 20px;
+export const WaitingButton = styled(Button)`
+  background-color: ${({ theme }) => theme.color.yellow};
 `;

--- a/src/components/MatchDetail/MatchDetail.styles.ts
+++ b/src/components/MatchDetail/MatchDetail.styles.ts
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
 
-import { Button } from '@components/Button/Button.styles';
-
 export const Container = styled.div`
   padding: 16px 24px;
 `;
@@ -15,10 +13,6 @@ export const Title = styled.span`
   font-size: 28px;
 `;
 
-export const Info = styled.div`
-  padding: 24px 0 8px;
-`;
-
 export const Detail = styled.div`
   padding: 8px 0;
 `;
@@ -30,12 +24,4 @@ export const DetailItem = styled.span`
 
 export const DetailTitle = styled.span`
   font-size: 16px;
-`;
-
-export const RefuseButton = styled(Button)`
-  background-color: ${({ theme }) => theme.color.primary};
-`;
-
-export const WaitingButton = styled(Button)`
-  background-color: ${({ theme }) => theme.color.yellow};
 `;

--- a/src/components/MatchDetail/MatchDetail.tsx
+++ b/src/components/MatchDetail/MatchDetail.tsx
@@ -79,7 +79,9 @@ const PostDetail = () => {
       <S.Info>
         <S.Detail>
           <S.DetailTitle>작성자 </S.DetailTitle>
-          <S.DetailTitle> {matchDetail?.author.nickname}</S.DetailTitle>
+          <S.DetailItem> {matchDetail?.author.nickname}</S.DetailItem>
+        </S.Detail>
+        <S.Detail>
           <S.DetailTitle>종목 </S.DetailTitle>
           <S.DetailItem>{SPORTS_TEXT[matchDetail?.sportsCategory as string]} </S.DetailItem>
         </S.Detail>

--- a/src/components/MatchDetail/MatchDetail.tsx
+++ b/src/components/MatchDetail/MatchDetail.tsx
@@ -92,7 +92,9 @@ const PostDetail = () => {
           >
             <S.Detail>
               <S.DetailTitle>팀명 </S.DetailTitle>
-              <S.DetailItem>{matchDetail?.team?.name} </S.DetailItem>
+              <S.DetailItem>
+                {matchDetail?.team?.name} / {matchDetail.participants}명
+              </S.DetailItem>
             </S.Detail>
             <Link
               href={`/team/${matchDetail.team.id}`}

--- a/src/components/MatchDetail/MatchDetail.tsx
+++ b/src/components/MatchDetail/MatchDetail.tsx
@@ -13,7 +13,7 @@ import { MATCH_STATUS_TEXT, MATCH_TYPE_TEXT, SPORTS_TEXT } from '@constants/text
 import { Proposer } from '@interface/match';
 import { Response } from '@interface/response';
 import { userState } from '@recoil/atoms';
-import { Anchor, InnerWrapper, RowWrapper } from '@styles/common';
+import { Anchor, ColWrapper, InnerWrapper, RowWrapper } from '@styles/common';
 
 import * as S from './MatchDetail.styles';
 import { MatchDetail } from './types';
@@ -53,66 +53,68 @@ const PostDetail = () => {
 
   return (
     <S.Container>
-      <RowWrapper
-        justifyContent='space-between'
-        alignItems='center'
-      >
+      <RowWrapper>
         <S.Title>{matchDetail?.title}</S.Title>
-        {isAuthor ? (
-          <Dropdown
-            round
-            placeholder={MATCH_STATUS_TEXT[status]}
-            items={MATCH_STATUS_DETAIL}
-            onSelect={handleSelect}
-          />
-        ) : (
-          <Badge
-            fontSize='16px'
-            width='89px'
-            height='32px'
-            color='secondary'
-          >
-            {MATCH_STATUS_TEXT[status]}
-          </Badge>
-        )}
       </RowWrapper>
-      <S.Info>
-        <S.Detail>
-          <S.DetailTitle>작성자 </S.DetailTitle>
-          <S.DetailItem> {matchDetail?.author.nickname}</S.DetailItem>
-        </S.Detail>
-        <S.Detail>
-          <S.DetailTitle>종목 </S.DetailTitle>
-          <S.DetailItem>{SPORTS_TEXT[matchDetail?.sportsCategory as string]} </S.DetailItem>
-        </S.Detail>
-        <S.Detail>
-          <S.DetailTitle>개인전/팀전 </S.DetailTitle>
-          <S.DetailItem>{MATCH_TYPE_TEXT[matchDetail?.matchType as string]} </S.DetailItem>
-        </S.Detail>
-        {matchDetail?.team && (
-          <InnerWrapper
-            alignItems='center'
-            justifyContent='space-between'
-          >
-            <S.Detail>
-              <S.DetailTitle>팀명 </S.DetailTitle>
-              <S.DetailItem>
-                {matchDetail?.team?.name} / {matchDetail.participants}명
-              </S.DetailItem>
-            </S.Detail>
-            <Link
-              href={`/team/${matchDetail.team.id}`}
-              passHref
+      <RowWrapper justifyContent='space-between'>
+        <ColWrapper>
+          <S.Detail>
+            <S.DetailTitle>작성자 </S.DetailTitle>
+            <S.DetailItem> {matchDetail?.author.nickname}</S.DetailItem>
+          </S.Detail>
+          <S.Detail>
+            <S.DetailTitle>종목 </S.DetailTitle>
+            <S.DetailItem>{SPORTS_TEXT[matchDetail?.sportsCategory as string]} </S.DetailItem>
+          </S.Detail>
+          <S.Detail>
+            <S.DetailTitle>개인전/팀전 </S.DetailTitle>
+            <S.DetailItem>{MATCH_TYPE_TEXT[matchDetail?.matchType as string]} </S.DetailItem>
+          </S.Detail>
+          {matchDetail?.team && (
+            <InnerWrapper
+              alignItems='center'
+              justifyContent='space-between'
             >
-              <Anchor>팀 정보 보러 가기</Anchor>
-            </Link>
-          </InnerWrapper>
-        )}
-        <S.Detail>
-          <S.DetailTitle>경기일자 </S.DetailTitle>
-          <S.DetailItem>{matchDetail?.matchDate} </S.DetailItem>
-        </S.Detail>
-      </S.Info>
+              <S.Detail>
+                <S.DetailTitle>팀명 </S.DetailTitle>
+                <S.DetailItem>
+                  {matchDetail?.team?.name} / {matchDetail.participants}명
+                </S.DetailItem>
+              </S.Detail>
+              <Link
+                href={`/team/${matchDetail.team.id}`}
+                passHref
+              >
+                <Anchor>팀 정보 보러 가기</Anchor>
+              </Link>
+            </InnerWrapper>
+          )}
+          <S.Detail>
+            <S.DetailTitle>경기일자 </S.DetailTitle>
+            <S.DetailItem>{matchDetail?.matchDate} </S.DetailItem>
+          </S.Detail>
+        </ColWrapper>
+        <ColWrapper>
+          {isAuthor ? (
+            <Dropdown
+              round
+              placeholder={MATCH_STATUS_TEXT[status]}
+              items={MATCH_STATUS_DETAIL}
+              onSelect={handleSelect}
+            />
+          ) : (
+            <Badge
+              fontSize='16px'
+              width='auto'
+              height='32px'
+              color='secondary'
+              padding
+            >
+              {MATCH_STATUS_TEXT[status]}
+            </Badge>
+          )}
+        </ColWrapper>
+      </RowWrapper>
       <RowWrapper>
         <Paragraph width='100%'>{matchDetail?.content}</Paragraph>
       </RowWrapper>
@@ -132,27 +134,13 @@ const PostDetail = () => {
           passHref
         >
           <Anchor>
-            <Button>신청하기</Button>
+            <Button>대결 신청</Button>
           </Anchor>
         </Link>
       )}
-      {!isAuthor && matchDetail?.proposer?.status === 'WAITING' && (
-        <S.WaitingButton
-          width='100%'
-          height='50px'
-          fontSize='20px'
-        >
-          승인 대기
-        </S.WaitingButton>
-      )}
+      {!isAuthor && matchDetail?.proposer?.status === 'WAITING' && <Button backgroundColor='yellow'>승인 대기</Button>}
       {!isAuthor && matchDetail?.proposer?.status === 'REFUSE' && (
-        <S.RefuseButton
-          width='100%'
-          height='50px'
-          fontSize='20px'
-        >
-          대화가 거절되었습니다
-        </S.RefuseButton>
+        <Button backgroundColor='primary'>신청이 거절되었습니다</Button>
       )}
       {!isAuthor && matchDetail?.proposer?.status === 'APPROVED' && proposer && (
         <Link
@@ -160,7 +148,7 @@ const PostDetail = () => {
           passHref
         >
           <Anchor>
-            <Button>채팅 하기</Button>
+            <Button>채팅</Button>
           </Anchor>
         </Link>
       )}

--- a/src/components/MatchDetail/MatchDetail.tsx
+++ b/src/components/MatchDetail/MatchDetail.tsx
@@ -78,6 +78,8 @@ const PostDetail = () => {
       </RowWrapper>
       <S.Info>
         <S.Detail>
+          <S.DetailTitle>작성자 </S.DetailTitle>
+          <S.DetailTitle> {matchDetail?.author.nickname}</S.DetailTitle>
           <S.DetailTitle>종목 </S.DetailTitle>
           <S.DetailItem>{SPORTS_TEXT[matchDetail?.sportsCategory as string]} </S.DetailItem>
         </S.Detail>
@@ -122,27 +124,44 @@ const PostDetail = () => {
           </Anchor>
         </Link>
       )}
-      {!isAuthor &&
-        status === 'WAITING' &&
-        (proposer && proposer.status === 'APPROVED' ? (
-          <Link
-            href={`/chatlist/${proposer.id}`}
-            passHref
-          >
-            <Anchor>
-              <Button>채팅 하기</Button>
-            </Anchor>
-          </Link>
-        ) : (
-          <Link
-            href={`/matches/${id as string}/proposal`}
-            passHref
-          >
-            <Anchor>
-              <Button>신청하기</Button>
-            </Anchor>
-          </Link>
-        ))}
+      {!isAuthor && matchDetail?.proposer === null && (
+        <Link
+          href={`/matches/${id as string}/proposal`}
+          passHref
+        >
+          <Anchor>
+            <Button>신청하기</Button>
+          </Anchor>
+        </Link>
+      )}
+      {!isAuthor && matchDetail?.proposer?.status === 'WAITING' && (
+        <S.WaitingButton
+          width='100%'
+          height='50px'
+          fontSize='20px'
+        >
+          승인 대기
+        </S.WaitingButton>
+      )}
+      {!isAuthor && matchDetail?.proposer?.status === 'REFUSE' && (
+        <S.RefuseButton
+          width='100%'
+          height='50px'
+          fontSize='20px'
+        >
+          대화가 거절되었습니다
+        </S.RefuseButton>
+      )}
+      {!isAuthor && matchDetail?.proposer?.status === 'APPROVED' && proposer && (
+        <Link
+          href={`/chatlist/${proposer.id}`}
+          passHref
+        >
+          <Anchor>
+            <Button>채팅 하기</Button>
+          </Anchor>
+        </Link>
+      )}
     </S.Container>
   );
 };

--- a/src/components/MatchDetail/MatchDetail.tsx
+++ b/src/components/MatchDetail/MatchDetail.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useRecoilState } from 'recoil';
 
 import { axiosAuthInstance } from '@api/axiosInstances';
+import { Badge } from '@components/Badge';
 import { Button } from '@components/Button';
 import { Dropdown, Item } from '@components/Dropdown';
 import { Paragraph } from '@components/Paragraph';
@@ -57,13 +58,23 @@ const PostDetail = () => {
         alignItems='center'
       >
         <S.Title>{matchDetail?.title}</S.Title>
-        <Dropdown
-          round
-          placeholder={MATCH_STATUS_TEXT[status]}
-          disabled={!isAuthor}
-          items={MATCH_STATUS_DETAIL}
-          onSelect={handleSelect}
-        />
+        {isAuthor ? (
+          <Dropdown
+            round
+            placeholder={MATCH_STATUS_TEXT[status]}
+            items={MATCH_STATUS_DETAIL}
+            onSelect={handleSelect}
+          />
+        ) : (
+          <Badge
+            fontSize='16px'
+            width='89px'
+            height='32px'
+            color='secondary'
+          >
+            {MATCH_STATUS_TEXT[status]}
+          </Badge>
+        )}
       </RowWrapper>
       <S.Info>
         <S.Detail>

--- a/src/components/MatchDetail/types.ts
+++ b/src/components/MatchDetail/types.ts
@@ -3,6 +3,12 @@ interface Author {
   nickname: string;
 }
 
+interface Proposer {
+  id: number;
+  status: string;
+  content: string;
+}
+
 interface Team {
   id: number;
   name: string;
@@ -22,10 +28,4 @@ export interface MatchDetail {
   status: string;
   team: Team | null;
   title: string;
-}
-
-export interface Proposer {
-  id: number;
-  status: string;
-  content: string;
 }

--- a/src/components/MatchListItem/MatchListItem.styles.ts
+++ b/src/components/MatchListItem/MatchListItem.styles.ts
@@ -28,9 +28,11 @@ export const TitleWrapper = styled.div`
   justify-content: space-between;
 `;
 
-export const Title = styled.span`
+export const Title = styled.div`
   font-size: 20px;
-  margin-right: 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 export const Content = styled.div`

--- a/src/components/MatchListItem/MatchListItem.tsx
+++ b/src/components/MatchListItem/MatchListItem.tsx
@@ -2,8 +2,7 @@ import Link from 'next/link';
 
 import { Badge } from '@components/Badge';
 import { MATCH_TYPE_TEXT, SPORTS_TEXT } from '@constants/text';
-import { B3, ColWrapper, InnerWrapper } from '@styles/common';
-import theme from '@styles/theme';
+import { B3, InnerWrapper } from '@styles/common';
 
 import * as S from './MatchListItem.styles';
 

--- a/src/components/TeamBadge/TeamBadge.styles.ts
+++ b/src/components/TeamBadge/TeamBadge.styles.ts
@@ -1,15 +1,10 @@
 import styled from '@emotion/styled';
 
-export const TeamBadgeWrapper = styled.div`
-  display: inline-block;
-  padding: 4px;
-`;
-
 export const BadgeInner = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 8px;
+  gap: 4px;
 `;
 
 export const IconWrapper = styled.div`

--- a/src/components/TeamBadge/TeamBadge.tsx
+++ b/src/components/TeamBadge/TeamBadge.tsx
@@ -23,19 +23,17 @@ const Color: ColorProps = {
 
 const TeamBadge = ({ team }: Props) => (
   <Link href={`/team/${team.id}`}>
-    <S.TeamBadgeWrapper>
-      <Badge
-        color={Color[Math.floor(Math.random() * 6 + 1)]}
-        width='100%'
-        height='38px'
-        borderRadius='5px'
-      >
-        <S.BadgeInner>
-          <SportsIcon sportsCategory={team.sportsCategory} />
-          <S.BadgeText>{team.name}</S.BadgeText>
-        </S.BadgeInner>
-      </Badge>
-    </S.TeamBadgeWrapper>
+    <Badge
+      color={Color[Math.floor(Math.random() * 6 + 1)]}
+      width='fit-content'
+      height='32px'
+      padding
+    >
+      <S.BadgeInner>
+        <SportsIcon sportsCategory={team.sportsCategory} />
+        <S.BadgeText>{team.name}</S.BadgeText>
+      </S.BadgeInner>
+    </Badge>
   </Link>
 );
 

--- a/src/interface/styles.ts
+++ b/src/interface/styles.ts
@@ -7,6 +7,7 @@ export interface WrapperProps {
   width?: string;
   height?: string;
   gap?: string;
+  wrap?: boolean;
 }
 
 export interface OptionalRenderProps {

--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -116,14 +116,17 @@ const UserDetailPage: NextPage = () => {
       <Divider />
       <ColWrapper gap='16px'>
         <Label>팀 목록</Label>
-        <div>
+        <InnerWrapper
+          gap='8px'
+          wrap
+        >
           {userInfo.teams.map((team: Team) => (
             <TeamBadge
               team={team}
               key={team.id}
             />
           ))}
-        </div>
+        </InnerWrapper>
       </ColWrapper>
       {isMe && (
         <>

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -40,6 +40,7 @@ export const InnerWrapper = styled.div<WrapperProps>`
   margin: ${(props) => props.margin};
   padding: ${(props) => props.padding};
   gap: ${(props) => props.gap || '8px'};
+  flex-wrap: ${(props) => (props.wrap ? 'wrap' : 'nowrap')};
 `;
 
 export const InlineWrapper = styled.div`


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
공고 상세 페이지 모집 중 버튼 글 작성자는 드롭다운, 일반 사용자는 뱃지로 보여주도록 수정하였습니다. 
참여 인원이 나오는 것이 신청 시 좋을 것 같아 참여 인원을 팀 이름 옆에 출력했습니다. 



- 작성자 
<img width="200px" height="300px" src="https://user-images.githubusercontent.com/82739503/184093522-2596943d-f8d4-46a8-bbba-cef6202ac765.png"/>

- WAITING, APPROVED, REFUSE 에 따라 버튼 분기했습니다.

<img width="200px" height="300px" src="https://user-images.githubusercontent.com/82739503/184093706-d3570ff0-0767-459a-a6d0-2c4a995467bc.png"/> <img width="200px" height="300px" src="https://user-images.githubusercontent.com/82739503/184093857-c286f8be-9172-4452-8a06-671c25a0f82e.png"/>

<img width="200px" height="300px" src="https://user-images.githubusercontent.com/82739503/184095256-f9072f92-1dfe-4d73-8e91-2062af44d026.png"/> <img width="200px" height="300px" src="https://user-images.githubusercontent.com/82739503/184095483-288f239a-418f-437e-8aa5-a713b0283f07.png"/>



