### PR TITLE
[DK-440] 팀 생성 페이지 1차 버그 픽스

### DIFF
--- a/src/components/TeamForm/TeamForm.tsx
+++ b/src/components/TeamForm/TeamForm.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 
 import { axiosAuthInstance } from '@api/axiosInstances';
@@ -5,11 +6,13 @@ import { Button } from '@components/Button';
 import { Dropdown, Item } from '@components/Dropdown';
 import { Input } from '@components/Input';
 import { SPORTS_CATEGORY } from '@constants/dropdown';
+import { Response } from '@interface/response';
 import { BoldOrangeB3, ColWrapper, Container, Label, TextArea } from '@styles/common';
 
 import { validation, Values } from './helper';
 
 const TeamForm = () => {
+  const router = useRouter();
   const [state, setState] = React.useState({
     sportsCategory: '',
     name: '',
@@ -41,11 +44,14 @@ const TeamForm = () => {
     }
 
     (async () => {
-      await axiosAuthInstance({
-        method: 'POST',
-        url: '/api/teams',
-        data: state,
+      const res = await axiosAuthInstance.post<Response<{ data: number }>>('/api/teams', {
+        name: state.name,
+        sportsCategory: state.sportsCategory,
+        description: state.description,
       });
+      if (res.status === 200) {
+        router.replace(`/team/${res.data.data.toString()}`);
+      }
     })();
   };
 

--- a/src/components/TeamForm/TeamForm.tsx
+++ b/src/components/TeamForm/TeamForm.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { axiosAuthInstance } from '@api/axiosInstances';
 import { Button } from '@components/Button';
 import { Dropdown, Item } from '@components/Dropdown';
 import { Input } from '@components/Input';
 import { SPORTS_CATEGORY } from '@constants/dropdown';
-import { ColWrapper, Container, Label, TextArea } from '@styles/common';
+import { BoldOrangeB3, ColWrapper, Container, Label, TextArea } from '@styles/common';
+
+import { validation, Values } from './helper';
 
 const TeamForm = () => {
   const [state, setState] = React.useState({
@@ -13,6 +15,8 @@ const TeamForm = () => {
     name: '',
     description: '',
   });
+  const [errors, setErrors] = React.useState<Values>({});
+  const [isFirst, setIsFirst] = React.useState(true);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -29,6 +33,13 @@ const TeamForm = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    setIsFirst(false);
+    const { name, description, sportsCategory } = state;
+    if (Object.keys(validation({ name, description, sportsCategory })).length > 0) {
+      setErrors(validation({ name, description, sportsCategory }));
+      return;
+    }
+
     (async () => {
       await axiosAuthInstance({
         method: 'POST',
@@ -37,6 +48,12 @@ const TeamForm = () => {
       });
     })();
   };
+
+  useEffect(() => {
+    if (!isFirst) {
+      setErrors(validation({ name: state.name, description: state.description, sportsCategory: state.sportsCategory }));
+    }
+  }, [state]);
 
   return (
     <Container>
@@ -49,17 +66,21 @@ const TeamForm = () => {
             placeholder='팀 이름'
             onChange={handleChange}
           />
+          {errors.name && <BoldOrangeB3>{errors.name}</BoldOrangeB3>}
           <Dropdown
             items={SPORTS_CATEGORY}
             placeholder='종목 선택'
             onSelect={handleSelect}
           />
+          {errors.sportsCategory && <BoldOrangeB3>{errors.sportsCategory}</BoldOrangeB3>}
           <Label>팀 소개글</Label>
           <TextArea
             name='description'
             placeholder='팀 소개'
             onChange={handleChange}
+            onKeyDown={(e) => e.key === 'Enter' && e.preventDefault()}
           />
+          {errors.description && <BoldOrangeB3>{errors.description}</BoldOrangeB3>}
           <Button width='100%'>팀 생성</Button>
         </ColWrapper>
       </form>

--- a/src/components/TeamForm/helper.ts
+++ b/src/components/TeamForm/helper.ts
@@ -1,0 +1,26 @@
+export interface Values {
+  name?: string;
+  sportsCategory?: string;
+  description?: string;
+}
+
+const regexTeamName = /^.{2,10}$/;
+const regexDescription = /^.{1,100}$/;
+
+export const validation = ({ name, sportsCategory, description }: Values) => {
+  const errors: Values = {};
+  if (!name) {
+    errors.name = '팀 이름을 입력해주세요.';
+  } else if (!regexTeamName.test(name)) {
+    errors.name = '너무 짧거나 너무 깁니다.';
+  }
+  if (!sportsCategory) {
+    errors.sportsCategory = '팀 종목을 선택해주세요.';
+  }
+  if (!description) {
+    errors.description = '팀 소개를 작성해주세요.';
+  } else if (!regexDescription.test(description)) {
+    errors.description = '너무 짧거나 너무 깁니다.';
+  }
+  return errors;
+};

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -1,3 +1,4 @@
+import { ThemeContext } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { WrapperProps } from 'interface/styles';
@@ -171,6 +172,11 @@ export const BoldGrayB3 = styled.span`
 export const BoldGreenB3 = styled.span`
   font-size: ${(props) => props.theme.fontSize.b3};
   color: ${(props) => props.theme.color.secondary};
+`;
+
+export const BoldOrangeB3 = styled.span`
+  font-size: ${({ theme }) => theme.fontSize.b3};
+  color: ${({ theme }) => theme.color.primary};
 `;
 
 export const GrayB4 = styled.span`

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -194,6 +194,7 @@ export const TextArea = styled.textarea`
   padding: 8px;
   height: 242px;
   font-size: ${(props) => props.theme.fontSize.b3};
+  font-family: inherit;
   ::placeholder {
     font-size: ${(props) => props.theme.fontSize.b3};
     color: ${({ theme }) => theme.color.gray400};


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
팀 생성 페이지 1차 버그 픽스

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
8f0dcdcc7600e540ce90d4e82b8af3c3f0e00ac1 TextArea 컴포넌트의 `font-family` 를 inherit으로 설정해 pretendard가 적용되도록 했습니다.
473ffce30a32bfdf3021d50bb70828cddbabc759 팀 생성 유효성 검사를 추가했습니다.
fdf86b54c6e26e07855a6e25eea4ee2e29b2830c 팀 생성 완료 시 생성한 팀 프로필 페이지로 이동하도록 했습니다.
