### PR TITLE
[DK-456] 매치 신청 시 공고 종목이 아닌 팀 필터링하도록 수정

### DIFF
--- a/src/pages/matches/[id]/proposal.tsx
+++ b/src/pages/matches/[id]/proposal.tsx
@@ -1,13 +1,15 @@
 import { NextPage } from 'next';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 
 import { axiosAuthInstance } from '@api/axiosInstances';
 import { Button } from '@components/Button';
 import { Dropdown, Item } from '@components/Dropdown';
+import { SPORTS_TEXT } from '@constants/text';
 import { Match } from '@interface/match';
 import { Response } from '@interface/response';
-import { Container, ColWrapper, TextArea } from '@styles/common';
+import { Container, ColWrapper, TextArea, BoldOrangeB3, Anchor } from '@styles/common';
 import { Team } from 'interface/team';
 
 const changeTeamsToDropdownItems = (teams: Team[]) =>
@@ -22,23 +24,19 @@ const Proposal: NextPage = () => {
   const [proposalData, setProposalData] = useState({ teamId: 0, content: '' });
 
   useEffect(() => {
-    (async () => {
-      setLoading(true);
-      const {
-        data: { data },
-      } = await axiosAuthInstance.get<Response<Team[]>>('/api/teams/me/leader');
-
-      setTeams(data);
-      setLoading(false);
-    })();
-  }, []);
-
-  useEffect(() => {
     if (!router.isReady) return;
     const getMatchInfoApi = async () => {
-      await axiosAuthInstance
-        .get<Response<Match>>(`/api/matches/${id as string}`)
-        .then((res) => setMatchInfo(res.data.data));
+      const res = await axiosAuthInstance.get<Response<Match>>(`/api/matches/${id as string}`);
+      setMatchInfo(res.data.data);
+      console.log(res.data.data);
+      (async () => {
+        setLoading(true);
+        const {
+          data: { data },
+        } = await axiosAuthInstance.get<Response<Team[]>>('/api/teams/me/leader');
+        setTeams(data.filter((item) => item.sportsCategory === res.data.data.sportsCategory));
+        setLoading(false);
+      })();
     };
     getMatchInfoApi();
   }, [id, router.isReady]);
@@ -79,11 +77,30 @@ const Proposal: NextPage = () => {
       <form onSubmit={handleSubmit}>
         <ColWrapper gap='16px'>
           {matchInfo?.matchType === 'TEAM_MATCH' ? (
-            <Dropdown
-              items={changeTeamsToDropdownItems(teams)}
-              onSelect={handleSelect}
-              placeholder='팀 선택'
-            />
+            <>
+              <Dropdown
+                items={changeTeamsToDropdownItems(teams)}
+                onSelect={handleSelect}
+                placeholder='팀 선택'
+                disabled={teams.length === 0}
+              />
+              {teams.length === 0 && (
+                <>
+                  <BoldOrangeB3>
+                    {SPORTS_TEXT[matchInfo?.sportsCategory]} 팀이 없습니다. 새로운 팀을 만들어보세요.
+                  </BoldOrangeB3>
+                  <Link
+                    href='/team/create'
+                    passHref
+                    replace
+                  >
+                    <Anchor>
+                      <Button>새 팀 생성하기</Button>
+                    </Anchor>
+                  </Link>
+                </>
+              )}
+            </>
           ) : (
             <div />
           )}
@@ -92,7 +109,12 @@ const Proposal: NextPage = () => {
             placeholder='요청 내용을 입력해주세요'
             onChange={handleChange}
           />
-          <Button width='100%'>제출</Button>
+          <Button
+            width='100%'
+            disabled={matchInfo?.matchType === 'TEAM_MATCH' && teams.length === 0}
+          >
+            제출
+          </Button>
         </ColWrapper>
       </form>
     </Container>

--- a/src/pages/matches/[id]/proposal.tsx
+++ b/src/pages/matches/[id]/proposal.tsx
@@ -18,7 +18,6 @@ const changeTeamsToDropdownItems = (teams: Team[]) =>
 const Proposal: NextPage = () => {
   const router = useRouter();
   const { id } = router.query;
-  const [loading, setLoading] = useState(false);
   const [teams, setTeams] = useState<Team[]>([]);
   const [matchInfo, setMatchInfo] = useState<Match>();
   const [proposalData, setProposalData] = useState({ teamId: 0, content: '' });
@@ -30,12 +29,10 @@ const Proposal: NextPage = () => {
       setMatchInfo(res.data.data);
       console.log(res.data.data);
       (async () => {
-        setLoading(true);
         const {
           data: { data },
         } = await axiosAuthInstance.get<Response<Team[]>>('/api/teams/me/leader');
         setTeams(data.filter((item) => item.sportsCategory === res.data.data.sportsCategory));
-        setLoading(false);
       })();
     };
     getMatchInfoApi();

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -1,4 +1,3 @@
-import { ThemeContext } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { WrapperProps } from 'interface/styles';


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
매치 신청 시 공고 종목이 아닌 팀 필터링하도록 수정

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
매치 신청 시 공고 종목이 아닌 팀 필터링하도록 수정했습니다.
해당 종목에 팀이 없을 경우 아래와 같이 출력되도록 했습니다.
<img width="495" alt="image" src="https://user-images.githubusercontent.com/61747121/184318909-79ea61c5-3064-4920-81a5-cce1701fe351.png">
