### PR TITLE
fix: 다른 사용자 프로필 위치 정보 출력 수정

### DIFF
--- a/src/interface/user.ts
+++ b/src/interface/user.ts
@@ -9,10 +9,7 @@ export interface UserInfo {
     likeCount: number;
     dislikeCount: number;
   };
-  location: {
-    longitude: number;
-    latitude: number;
-  };
+  localName: string;
   teams: Team[];
 }
 

--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -34,10 +34,7 @@ const UserDetailPage: NextPage = () => {
       likeCount: 0,
       dislikeCount: 0,
     },
-    location: {
-      longitude: 0,
-      latitude: 0,
-    },
+    localName: '',
     teams: [],
   });
   const [address, setAddress] = React.useState<Address>({
@@ -128,7 +125,7 @@ const UserDetailPage: NextPage = () => {
           justifyContent='center'
         >
           <B1>{userInfo.nickname}</B1>
-          <GrayB3>{isMe && address.region_3depth_name}</GrayB3>
+          <GrayB3>{isMe ? address.region_3depth_name : userInfo.localName}</GrayB3>
         </InnerWrapper>
       </RowWrapper>
       {isMe && (


### PR DESCRIPTION
## 📌 개요 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
다른 사용자 프로필 위치 정보 출력 수정했습니다.

## 👩‍💻 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
내 프로필 조회 시 내 위치가 출력되고, 다른 사용자 프로필 조회 시 해당 사용자 위치가 출력되도록 했습니다.

close #126 
