### PR TITLE
[Refactor/147] Badge 컴포넌트 리팩터링

### DIFF
--- a/src/components/ChatListItem/ChatListItem.tsx
+++ b/src/components/ChatListItem/ChatListItem.tsx
@@ -1,5 +1,5 @@
 import { OldAvatar } from '@components/common/Avatar';
-import { Badge } from '@components/common/Badge';
+import { OldBadge } from '@components/common/Badge';
 
 import { MATCH_STATUS_TEXT } from '@constants/text';
 import { InnerWrapper, B1, TitleWrapper, ContentWrapper, BadgeWrapper, B4 } from '@styles/common';
@@ -43,7 +43,7 @@ const ChatListItem = ({ imgSrc, nickname, lastChat, match }: Props) => (
       >
         <B4>{nickname}</B4>
         <BadgeWrapper>
-          {match && <Badge matchStatus={match.status}>{MATCH_STATUS_TEXT[match.status]}</Badge>}
+          {match && <OldBadge matchStatus={match.status}>{MATCH_STATUS_TEXT[match.status]}</OldBadge>}
         </BadgeWrapper>
       </InnerWrapper>
     </InnerWrapper>

--- a/src/components/MatchDetail/MatchDetail.tsx
+++ b/src/components/MatchDetail/MatchDetail.tsx
@@ -6,7 +6,7 @@ import { ThreeDots } from 'react-loader-spinner';
 import { useRecoilState } from 'recoil';
 
 import { OldAvatar } from '@components/common/Avatar';
-import { Badge } from '@components/common/Badge';
+import { OldBadge } from '@components/common/Badge';
 import { Button } from '@components/common/Button';
 import { Dropdown, Item } from '@components/common/Dropdown';
 import { Paragraph } from '@components/common/Paragraph';
@@ -137,7 +137,7 @@ const PostDetail = () => {
               onSelect={handleSelect}
             />
           ) : (
-            <Badge
+            <OldBadge
               fontSize='16px'
               width='auto'
               height='32px'
@@ -146,7 +146,7 @@ const PostDetail = () => {
               matchStatus={status}
             >
               {MATCH_STATUS_TEXT[status]}
-            </Badge>
+            </OldBadge>
           )}
         </S.StatusWrapper>
       </RowWrapper>

--- a/src/components/MatchListItem/MatchListItem.tsx
+++ b/src/components/MatchListItem/MatchListItem.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import { Badge } from '@components/common/Badge';
+import { OldBadge } from '@components/common/Badge';
 
 import { MATCH_TYPE_TEXT, SPORTS_TEXT } from '@constants/text';
 import { GrayB4, InnerWrapper } from '@styles/common';
@@ -40,8 +40,8 @@ const MatchListItem = ({ id, title, category, matchType, content, createdAt, dis
           alignItems='flex-end'
         >
           <InnerWrapper>
-            <Badge>{SPORTS_TEXT[category]}</Badge>
-            <Badge matchType={matchType}>{MATCH_TYPE_TEXT[matchType]}</Badge>
+            <OldBadge>{SPORTS_TEXT[category]}</OldBadge>
+            <OldBadge matchType={matchType}>{MATCH_TYPE_TEXT[matchType]}</OldBadge>
           </InnerWrapper>
         </InnerWrapper>
         <InnerWrapper justifyContent='space-between'>

--- a/src/components/TeamBadge/TeamBadge.tsx
+++ b/src/components/TeamBadge/TeamBadge.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import { Badge } from '@components/common/Badge';
+import { OldBadge } from '@components/common/Badge';
 
 import { SportsIcon } from '@components/SportsIcon';
 import { Anchor } from '@styles/common';
@@ -25,7 +25,7 @@ const Color: ColorProps = {
 const TeamBadge = ({ team }: Props) => (
   <Link href={`/team/${team.id}`}>
     <Anchor>
-      <Badge
+      <OldBadge
         color={Color[Math.floor(Math.random() * 6 + 1)]}
         width='fit-content'
         height='32px'
@@ -38,7 +38,7 @@ const TeamBadge = ({ team }: Props) => (
           />
           <S.BadgeText>{team.name}</S.BadgeText>
         </S.BadgeInner>
-      </Badge>
+      </OldBadge>
     </Anchor>
   </Link>
 );

--- a/src/components/common/Badge/OldBadge.tsx
+++ b/src/components/common/Badge/OldBadge.tsx
@@ -12,7 +12,7 @@ interface Props {
   children?: string | JSX.Element;
 }
 
-const Badge = ({
+const OldBadge = ({
   matchType,
   matchStatus,
   color = 'primary',
@@ -37,4 +37,4 @@ const Badge = ({
   </S.Container>
 );
 
-export default Badge;
+export default OldBadge;

--- a/src/components/common/Badge/index.ts
+++ b/src/components/common/Badge/index.ts
@@ -1,1 +1,1 @@
-export { default as Badge } from './Badge';
+export { default as OldBadge } from './OldBadge';

--- a/src/components/common/Tag/Tag.tsx
+++ b/src/components/common/Tag/Tag.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import { ColorType } from '@emotion/react';
 import styled from '@emotion/styled';
-import React from 'react';
 
 interface StyleProps {
   bgColor: ColorType;

--- a/src/components/common/Tag/Tag.tsx
+++ b/src/components/common/Tag/Tag.tsx
@@ -1,0 +1,31 @@
+import { ColorType } from '@emotion/react';
+import styled from '@emotion/styled';
+import React from 'react';
+
+interface StyleProps {
+  bgColor: ColorType;
+}
+
+interface Props extends StyleProps {
+  children: React.ReactNode | string;
+}
+
+const Tag = ({ bgColor, children }: Props) => <TagRoot bgColor={bgColor}>{children}</TagRoot>;
+
+export default Tag;
+
+const TagRoot = styled('div')<StyleProps>(
+  {
+    minWidth: 64,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: '4px 8px',
+  },
+  ({ theme, bgColor }) => ({
+    backgroundColor: theme.color[bgColor],
+    color: theme.color.background,
+    fontSize: theme.fontSize.c1,
+    borderRadius: theme.borderRadius,
+  }),
+);

--- a/src/components/common/Tag/index.ts
+++ b/src/components/common/Tag/index.ts
@@ -1,0 +1,1 @@
+export { default as Tag } from './Tag';

--- a/src/pages/chatlist/[matchProposalId].tsx
+++ b/src/pages/chatlist/[matchProposalId].tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
 
-import { Badge } from '@components/common/Badge';
+import { OldBadge } from '@components/common/Badge';
 import { Button } from '@components/common/Button';
 import { Dropdown, Item } from '@components/common/Dropdown';
 import { Navigator } from '@components/common/Navigator';
@@ -234,7 +234,7 @@ const Chats: NextPage = () => {
             </Link>
           </ChatMatchTitleWrapper>
           {!proposal.isMatchAuthor ? (
-            <Badge
+            <OldBadge
               matchStatus={matchStatus}
               width='100px'
               height='32px'
@@ -242,7 +242,7 @@ const Chats: NextPage = () => {
               padding
             >
               {MATCH_STATUS_TEXT[matchStatus]}
-            </Badge>
+            </OldBadge>
           ) : (
             <DropdownWrapper>
               {matchStatus === 'WAITING' ? (

--- a/src/types/emotion.d.ts
+++ b/src/types/emotion.d.ts
@@ -1,26 +1,30 @@
 import '@emotion/react';
 
+interface Color {
+  primary: string;
+  primaryHover: string;
+  primaryActive: string;
+  secondary: string;
+  secondaryHover: string;
+  secondaryActive: string;
+  background: string;
+  yellow: string;
+  gray700: string;
+  gray600: string;
+  gray500: string;
+  gray400: string;
+  gray300: string;
+  gray200: string;
+  gray100: string;
+  green200: string;
+  green100: string;
+}
+
 declare module '@emotion/react' {
-  export interface Theme {
-    color: {
-      primary: string;
-      primaryHover: string;
-      primaryActive: string;
-      secondary: string;
-      secondaryHover: string;
-      secondaryActive: string;
-      background: string;
-      yellow: string;
-      gray700: string;
-      gray600: string;
-      gray500: string;
-      gray400: string;
-      gray300: string;
-      gray200: string;
-      gray100: string;
-      green200: string;
-      green100: string;
-    };
+  type ColorType = keyof Color;
+
+  interface Theme {
+    color: Color;
     fontSize: {
       h1: string;
       h2: string;


### PR DESCRIPTION
### 📌 개요

- [x] 도메인 관련 코드 삭제
> Badge 컴포넌트는 공통 컴포넌트임에도 macthType matchStatus 라는 도메인 관련 props에 의해 조작될 수 있습니다
> 이를 해결하기 위해 도메인 관련 코드를 제거하고자 합니다

- [x] 네이밍 변경
> Badge라는 이름이 적절하지 않다고 생각됩니다
> 네이밍을 Tag으로 변경하고자 합니다

- [x] 컬러 지정 범위 축소
> 컬러 지정을 테마에 지정해둔 것이 아닌 다른 컬러들도 지정이 되는데 범위를 테마 내부 컬러로 축소시켜 디자인 일관성을 강제?할 수 있습니다

- [x] props 범위 축소
> 각각의 여러가지 스타일 관련 props를 제거하고 props로 조작가능한 범위를 줄이고자 합니다
> 기능을 추가하기 위해서는 최소화된 코드가 적절하다고 생각합니다


### 👩‍💻 구현 내용

498387cee4d75dbde0c0f807de9fd35fd53aba37

기존 기능 변화와 에러를 방지하기 위해 Old prefix를 붙여서 기존 코드를 보존해두었습니다

6f0f632d1988350930df6f30f13faa8aa5b7abd0

컬러 지정 범위 축소를 위해 선언한 타입입니다

a8407ac071a4e901a9d3be36f09fe81684e3c88d

컴포넌트 네이밍 변경과 props를 최소화하여 Chip 컴포넌트를 구현했습니다

23e8025846a4fd89e2f4be35707e9fdc1d119411

이전 PR에 있는 커밋이라 머지할 때 삭제할 예정입니다

close #147 