### PR TITLE
[Refactor/140] ChatlistItem 컴포넌트 리팩토링

### DIFF
--- a/src/components/ChatListItem/ChatListItem.styles.ts
+++ b/src/components/ChatListItem/ChatListItem.styles.ts
@@ -1,12 +1,42 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.div`
-  display: flex;
-  gap: 16px;
-  cursor: pointer;
-`;
+export const Container = styled('div')({
+  display: 'flex',
+  gap: '16px',
+  cursor: 'pointer',
+});
 
-export const GrayB3 = styled.span`
-  font-size: ${(props) => props.theme.fontSize.b3};
-  color: ${(props) => props.theme.color.gray400};
-`;
+export const ChatInfoContainer = styled('div')({
+  display: 'flex',
+  width: 'calc(100% -88px)',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  flexGrow: '1',
+  gap: '8px',
+});
+
+export const MatchTitleWrapper = styled('div')({
+  fontSize: '20px',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const LastChatWrapper = styled('div')({
+  maxWidth: '250px',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const MatchInfoContainer = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const MatchBadgeWrapper = styled('div')({
+  display: 'flex',
+  alignItems: 'flex-end',
+  justifyContent: 'flex-end',
+});

--- a/src/components/ChatListItem/ChatListItem.tsx
+++ b/src/components/ChatListItem/ChatListItem.tsx
@@ -1,4 +1,4 @@
-import { OldAvatar } from '@components/common/Avatar';
+import { Avatar, OldAvatar } from '@components/common/Avatar';
 import { OldBadge } from '@components/common/Badge';
 
 import { MATCH_STATUS_TEXT } from '@constants/text';
@@ -17,19 +17,18 @@ interface Props {
 const ChatListItem = ({ imgSrc, nickname, lastChat, match }: Props) => (
   <S.Container>
     {imgSrc !== null ? (
-      <OldAvatar
-        imgSrc={imgSrc}
-        imgSize='72px'
-        borderRadius='50%'
+      <Avatar
+        src={imgSrc}
+        size='72px'
       />
     ) : (
-      <OldAvatar imgSize='72px' />
+      <Avatar size='72px' />
     )}
     <InnerWrapper
+      width='calc(100% - 88px)'
       flexDirection='column'
       justifyContent='center'
       flexGrow={1}
-      width='calc(100% - 88px)'
     >
       <TitleWrapper>
         <B1>{match?.title}</B1>

--- a/src/components/ChatListItem/ChatListItem.tsx
+++ b/src/components/ChatListItem/ChatListItem.tsx
@@ -1,8 +1,8 @@
-import { Avatar, OldAvatar } from '@components/common/Avatar';
+import { Avatar } from '@components/common/Avatar';
 import { OldBadge } from '@components/common/Badge';
+import Text from '@components/common/Text/Text';
 
 import { MATCH_STATUS_TEXT } from '@constants/text';
-import { InnerWrapper, B1, TitleWrapper, ContentWrapper, BadgeWrapper, B4 } from '@styles/common';
 import { Match } from 'types';
 
 import * as S from './ChatListItem.styles';
@@ -24,28 +24,20 @@ const ChatListItem = ({ imgSrc, nickname, lastChat, match }: Props) => (
     ) : (
       <Avatar size='72px' />
     )}
-    <InnerWrapper
-      width='calc(100% - 88px)'
-      flexDirection='column'
-      justifyContent='center'
-      flexGrow={1}
-    >
-      <TitleWrapper>
-        <B1>{match?.title}</B1>
-      </TitleWrapper>
-      <ContentWrapper>
-        <S.GrayB3>{lastChat}</S.GrayB3>
-      </ContentWrapper>
-      <InnerWrapper
-        alignItems='center'
-        justifyContent='space-between'
-      >
-        <B4>{nickname}</B4>
-        <BadgeWrapper>
+    <S.ChatInfoContainer>
+      <S.MatchTitleWrapper>
+        <Text tag='b1'>{match?.title}</Text>
+      </S.MatchTitleWrapper>
+      <S.LastChatWrapper>
+        <Text tag='grayB3'>{lastChat}</Text>
+      </S.LastChatWrapper>
+      <S.MatchInfoContainer>
+        <Text tag='b4'>{nickname}</Text>
+        <S.MatchBadgeWrapper>
           {match && <OldBadge matchStatus={match.status}>{MATCH_STATUS_TEXT[match.status]}</OldBadge>}
-        </BadgeWrapper>
-      </InnerWrapper>
-    </InnerWrapper>
+        </S.MatchBadgeWrapper>
+      </S.MatchInfoContainer>
+    </S.ChatInfoContainer>
   </S.Container>
 );
 export default ChatListItem;

--- a/src/components/common/Text/Text.styles.ts
+++ b/src/components/common/Text/Text.styles.ts
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+
+export interface StyleProps {
+  tag?: string;
+  fontSize?: string;
+  fontWeight?: string | number;
+  fontStyle?: string;
+  color?: string;
+}
+
+export const StyledText = styled('span')<StyleProps>({}, ({ theme, tag, fontSize, fontWeight, fontStyle, color }) => {
+  const getFontSize = () => {
+    if (tag) {
+      const compareTag = tag.toLowerCase();
+      if (compareTag.includes('h1')) return theme.fontSize.h1;
+      if (compareTag.includes('h2')) return theme.fontSize.h2;
+      if (compareTag.includes('b1')) return theme.fontSize.b1;
+      if (compareTag.includes('b2')) return theme.fontSize.b2;
+      if (compareTag.includes('b3')) return theme.fontSize.b3;
+      if (compareTag.includes('b4')) return theme.fontSize.b4;
+      if (compareTag.includes('c1')) return theme.fontSize.c1;
+      if (compareTag.includes('c2')) return theme.fontSize.c2;
+    }
+  };
+  const getFontWeight = () => {
+    if (tag && tag.toLowerCase().includes('bold')) return 'bold';
+  };
+  const getFontStyle = () => {
+    if (tag && tag.toLowerCase().includes('normal')) return 'normal';
+    if (tag && tag.toLowerCase().includes('italic')) return 'italic';
+    if (tag && tag.toLowerCase().includes('oblique')) return 'oblique';
+    if (tag && tag.toLowerCase().includes('initial')) return 'initial';
+  };
+  const getColor = () => {
+    if (tag && tag.toLowerCase().includes('gray')) return theme.color.gray400;
+    if (tag && tag.toLowerCase().includes('green')) return theme.color.secondary;
+    if (tag && tag.toLowerCase().includes('orange')) return theme.color.primary;
+  };
+  return {
+    fontSize: fontSize || getFontSize(),
+    fontWeight: fontWeight || getFontWeight(),
+    fontStyle: fontStyle || getFontStyle(),
+    color: color || getColor(),
+  };
+});

--- a/src/components/common/Text/Text.tsx
+++ b/src/components/common/Text/Text.tsx
@@ -1,0 +1,45 @@
+import * as S from './Text.styles';
+
+interface Props extends Partial<S.StyleProps> {
+  children?: string | JSX.Element;
+  tag?:
+    | 'h1'
+    | 'h2'
+    | 'b1'
+    | 'b2'
+    | 'b3'
+    | 'b4'
+    | 'c1'
+    | 'c2'
+    | 'boldB1'
+    | 'boldB2'
+    | 'boldB3'
+    | 'boldB4'
+    | 'boldC1'
+    | 'boldC2'
+    | 'grayB2'
+    | 'grayB3'
+    | 'grayB4'
+    | 'boldGrayB1'
+    | 'boldGrayB2'
+    | 'boldGrayB3'
+    | 'boldGreenB3'
+    | 'boldOrangeB3';
+  fontSize?: string;
+  fontWeight?: string | number;
+  fontStyle?: string;
+  color?: string;
+}
+
+const Text = ({ children, tag, fontSize, fontWeight, fontStyle, color }: Props) => (
+  <S.StyledText
+    tag={tag}
+    fontSize={fontSize}
+    fontWeight={fontWeight}
+    fontStyle={fontStyle}
+    color={color}
+  >
+    {children}
+  </S.StyledText>
+);
+export default Text;

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -37,7 +37,8 @@ export const useForm = <T>({ initialValue, initialError, initialSuccess, onSubmi
   useEffect(() => {
     if (isLoading) {
       // FIXME: Overload Error => 임시처리
-      if (Object.keys(errors as object).length === 0) {
+      // FIXME: unknown 임시 처리(jkb)
+      if (Object.keys(errors as unknown as object).length === 0) {
         onSubmit(values);
       }
       setIsLoading(false);

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -61,27 +61,6 @@ export const RadioWrapper = styled.div`
   gap: 8px;
 `;
 
-export const BadgeWrapper = styled.div`
-  display: flex;
-  align-items: flex-end;
-  justify-content: flex-end;
-`;
-
-export const TitleWrapper = styled.div`
-  font-size: 20px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-export const ContentWrapper = styled.div`
-  max-width: 250px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: ${(props) => props.theme.color.gray400};
-`;
-
 export const DropdownWrapper = styled.div<WrapperProps>`
   width: ${(props) => props.width};
 `;


### PR DESCRIPTION
### 📌 개요
ChatListItem 전체적인 구조 및 코드 리팩토링

- [x] 전체 코드, 구조 파악, 도메인 분리 시도
- [x] InnerWrapper 스타일 코드 분리
- [x] common 파일 내 코드 분리 및 불필요한 스타일 삭제
- [x] Text 컴포넌트 구현
- [x] 불필요한 CSS 삭제

### 👩‍💻 구현 내용

- 구현 사항(화면은 같지만 코드는 변경되었습니다.)
<img width="200" alt="스크린샷 2022-11-21 오전 11 36 40" src="https://user-images.githubusercontent.com/33307948/202985076-6c641e6f-f5a4-4839-80d2-f3498cf0e986.png">

[issue/140 [Refactor] ChatListItem](https://github.com/prgrms-web-devcourse/Team_04_SFam_FE/issues/140) 

이슈에 있는 내용들을 구현했습니다. 조금 내용을 정돈해보면 코드를 파악하고 더 좋은 코드 구조에 대한 고민, 도메인에 대한 고민을 해봤지만 코드 구조, 도메인 유지 모두 현재 코드 그대로 유지하기로 결정했습니다. 자세한 이유는 이슈에서 확인 부탁드려요.

### 현재 PR에서 진행한 사항은 다음과 같습니다.

[fix(useform): commitzen husky hook error 발생하여 임시 처리](https://github.com/prgrms-web-devcourse/Team_04_SFam_FE/commit/82c126306928389f97b076eb3bae3f7955722845)

![커밋 에러](https://user-images.githubusercontent.com/33307948/202992652-0955a0db-8afa-4f11-a626-897ce6761c6c.png)

 커밋을 할 때 위 스크린샷과  같은 에러가 발생하여 임시로 unknown 처리 해뒀습니다.

[refactor(chatlistitem): 리팩토링한 avatar 적용](https://github.com/prgrms-web-devcourse/Team_04_SFam_FE/commit/80389e13187eacb1fb0a7d18a3f23c2fdd896ca1)

리팩토링 해주신 avatar props에 맞춰서 적용시켰습니다.

[feat(text): text 컴포넌트 구현](https://github.com/prgrms-web-devcourse/Team_04_SFam_FE/commit/16243cbf275a586d9395df1de01a548ca6e40b35)

<img width="200" alt="스크린샷 2022-11-21 오후 1 02 05" src="https://user-images.githubusercontent.com/33307948/202993797-7b94948e-0ccb-456d-9f68-700294b9696b.png">

`tag`, `fontSize`, `fontWeight`, `fontStyle`, `color` 를 props로 받아 텍스트를 커스텀 할 수 있습니다.
현재는 if 문 때문에 아주 난잡해보이는데 말씀해주신 타입 적용을 해볼 생각입니다.
`tag`를 기존에 사용하던 `BoldB3` `boldGrayB1` 대소문자 구분없이 원하는 형태를 넣어서 해당하는 글자가 포함되는 경우 구현되도록 만들어뒀습니다. 더 좋은 방식이 있다면 말씀해주세요.

[refactor(chatlistitem): chatlistitem container, wrapper 명칭 수정, 불필요한 css 삭제](https://github.com/prgrms-web-devcourse/Team_04_SFam_FE/commit/b2c54909573c795d121c6637affb4e58fde1ae6b)

기존 `InnerWrapper`로 작업하던 justify-content, alignItems를 분리해봤습니다. 가독성 때문에 구분해뒀는데 한 곳으로 컴포넌트처럼 쓰던 거라 굳이 이렇게 할 필요성이 있을까 생각도 했습니다. 의견 부탁드립니다.
개인적으로 InnerWrapper라는 명칭을 바꾸는게 더 괜찮아보이기도 합니다.
`LayoutWrapper` 혹은 `FlexWrapper` 명칭은 잘 모르겠네요.

### ✅ PR 포인트 & 궁금한 점

- 더 좋은 방식의 Text 구현방식(includes(), type 등등) 리뷰 부탁드려요!
- OldBadge 명칭을 matchStatusBadge라고 변경하는게 좋을 것 같다고 생각하는데 어떻게 생각하시나요?
- InnerWrapper의 명칭 변경에 대해서 어떻게 생각하시나요?

close #140 
